### PR TITLE
Integration with Bloop

### DIFF
--- a/bloop-dap/src/main/scala/bloop/bsp/dap/BloopDebuggeeRunner.scala
+++ b/bloop-dap/src/main/scala/bloop/bsp/dap/BloopDebuggeeRunner.scala
@@ -80,6 +80,8 @@ private final class MainClassDebugAdapter(
     initialState: State,
     ioScheduler: Scheduler
 ) extends BloopDebuggeeRunner(initialState, ioScheduler) {
+
+  def name: String = s"[MainClass ${mainClass.`class`} in ${project.name}]"
   def start(state: State): Task[ExitStatus] = {
     val workingDir = state.commonOptions.workingPath
     val runState = Tasks.runJVM(
@@ -104,6 +106,7 @@ private final class TestSuiteDebugAdapter(
     initialState: State,
     ioScheduler: Scheduler
 ) extends BloopDebuggeeRunner(initialState, ioScheduler) {
+  def name: String = projects.map(_.name).mkString("[TestSuites in ", ",", "]")
   def start(state: State): Task[ExitStatus] = {
     val filter = TestInternals.parseFilters(filters)
     val handler = new LoggingEventHandler(state.logger)
@@ -124,6 +127,7 @@ private final class TestSuiteDebugAdapter(
 
 private final class AttachRemoteDebugAdapter(initialState: State, ioScheduler: Scheduler
 ) extends BloopDebuggeeRunner(initialState, ioScheduler) {
+  override def name: String = "Remote"
   override def start(state: State): Task[ExitStatus] = Task(ExitStatus.Ok)
 }
 

--- a/bloop-dap/src/main/scala/bloop/bsp/dap/DebugSessionLogger.scala
+++ b/bloop-dap/src/main/scala/bloop/bsp/dap/DebugSessionLogger.scala
@@ -29,7 +29,7 @@ class DebugSessionLogger(callbacks: DebugSessionCallbacks, underlying: Logger) e
 
   override def error(msg: String): Unit = {
     underlying.error(msg)
-    callbacks.printErr(msg)
+    callbacks.printlnErr(msg)
   }
 
   override def info(msg: String): Unit = {
@@ -42,7 +42,7 @@ class DebugSessionLogger(callbacks: DebugSessionCallbacks, underlying: Logger) e
         callbacks.onListening(address)
       }
     } else {
-      callbacks.printOut(msg)
+      callbacks.printlnOut(msg)
     }
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -3,21 +3,16 @@
 import java.io.File
 
 inThisBuild(
-  List(
+  Seq(
+    organization := "ch.epfl.scala",
+    version := "1.0.0-SNAPSHOT",
     onLoadMessage := s"Welcome to scala-debug-adapter ${version.value}",
     scalaVersion := Dependencies.scala212,
-    Keys.resolvers := {
-      val oldResolvers = Keys.resolvers.value
-      val sonatypeStaging = Resolver.sonatypeRepo("staging")
-      val scalametaResolver = Resolver.bintrayRepo("scalameta", "maven")
-      val scalacenterResolver = Resolver.bintrayRepo("scalacenter", "releases")
-      (oldResolvers :+ sonatypeStaging :+ scalametaResolver :+ scalacenterResolver).distinct
-    },
-    //crossScalaVersions := List(Dependencies.scala213, Dependencies.scala212, Dependencies.scala211),
+    // resolvers ++= Seq(
+    //   Resolver.bintrayRepo("scalacenter", "releases")
+    // )
   )
 )
-
-val bloopVersion = "1.4.5" // "1.4.6-15-209c2a5c" // "1.4.6"
 
 lazy val core = project
   .enablePlugins(SbtJdiTools, BuildInfoPlugin)
@@ -57,8 +52,6 @@ lazy val bloopDap = project
   .in(file("bloop-dap"))
   .settings(
     name := "bloop-scala-debug-adapter",
-    libraryDependencies ++= List(
-      "ch.epfl.scala" %% "bloop-frontend" % bloopVersion
-    )
+    libraryDependencies ++= Seq(Dependencies.bloopFrontend)
   )
   .dependsOn(core)

--- a/core/src/main/scala/dap/CancelableFuture.scala
+++ b/core/src/main/scala/dap/CancelableFuture.scala
@@ -6,6 +6,6 @@ import scala.concurrent.Future
   * As soon as cancel is called, future is supposed to return
   */
 trait CancelableFuture[T] {
-  def future(): Future[T]
+  def future: Future[T]
   def cancel(): Unit
 }

--- a/core/src/main/scala/dap/DebugServer.scala
+++ b/core/src/main/scala/dap/DebugServer.scala
@@ -1,16 +1,20 @@
 package dap
 
 import com.microsoft.java.debug.core.DebugSettings
-import dap.DebugSession.{Restarted, Terminated}
+import dap.DebugSession.Restarted
 
 import java.net.{InetSocketAddress, ServerSocket, URI}
-import java.util.concurrent.ConcurrentLinkedQueue
-import java.util.concurrent.atomic.AtomicBoolean
-import scala.concurrent.{ExecutionContext, Future}
+import java.util.concurrent.{ConcurrentLinkedQueue, TimeUnit}
 import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
-class DebugServer(runner: DebuggeeRunner, logger: Logger)(implicit ec: ExecutionContext) {
+final class DebugServer private (
+  runner: DebuggeeRunner,
+  logger: Logger,
+  autoCloseSession: Boolean,
+  gracePeriod: Duration
+)(implicit ec: ExecutionContext) {
 
   /**
    * Disable evaluation of variable's `toString` methods
@@ -26,50 +30,117 @@ class DebugServer(runner: DebuggeeRunner, logger: Logger)(implicit ec: Execution
   DebugSettings.getCurrent.showToString = false
 
   private val address = new InetSocketAddress(0)
-  private val closedServer = new AtomicBoolean(false)
+  private var closedServer = false
   private val ongoingSessions = new ConcurrentLinkedQueue[DebugSession]()
+  private val lock = new Object()
 
   /*
    * Set backlog to 1 to recommend the OS to process one connection at a time,
    * which can happen when a restart is request and the client immediately
    * connects without waiting for the other session to finish.
    */
-  private val server = new ServerSocket(address.getPort, 1, address.getAddress)
+  private val serverSocket = new ServerSocket(address.getPort, 1, address.getAddress)
 
-  val uri: URI = URI.create(s"tcp://${address.getHostString}:${server.getLocalPort}")
+  def uri: URI = URI.create(s"tcp://${address.getHostString}:${serverSocket.getLocalPort}")
 
   /**
-    * Continually connect until current session returns `Terminated`
+    * Wait for a connection then start a session
+    * If the session returns [[DebugSession.Restarted]], wait for a new connection and start a new session
+    * Until the session returns [[DebugSession.Terminated]] or [[DebugSession.Disconnected]]
     */
-  def start(): Future[Unit] = Future {
-    val session = connect()
-    session.exitStatus.map {
-      case Restarted => start()
-      case Terminated => Future.successful(())
-    }.flatten
+  def start(): Future[Unit] = {
+    for {
+      session <- Future(connect())
+      exitStatus <- session.exitStatus
+      restarted <- exitStatus match {
+        case Restarted => start()
+        case _ => Future.successful(())
+      }
+    } yield restarted
   }
 
   /**
-    * Connect once and return current session
+    * Connect once and return a running session
+    * In case of race condition with the [[close]] method, the session can be closed before returned
     */
   def connect(): DebugSession = {
-    val socket = server.accept()
-    val session = DebugSession(socket, runner, logger)
-    ongoingSessions.add(session)
-    session.start()
-    session
+    val socket = serverSocket.accept()
+    val session = DebugSession(socket, runner, logger, autoCloseSession, gracePeriod)
+    lock.synchronized {
+      if (closedServer) {
+        session.close()
+      } else {
+        ongoingSessions.add(session)
+        session.start()
+      }
+      session
+    }
   }
 
-  def close(gracePeriod: Duration = 1 millisecond): Unit = {
-    if (closedServer.compareAndSet(false, true)) {
-      ongoingSessions.forEach(_.cancel(gracePeriod))
-      try server.close()
-      catch {
-        case NonFatal(e) =>
-          logger.warn(
-            s"Could not close debug server listening on [$uri due to: ${e.getMessage}]"
-          )
+  def close(): Unit = {
+    lock.synchronized {
+      if (!closedServer) {
+        closedServer = true
+        ongoingSessions.forEach(_.close())
+        try {
+          logger.info(s"Closing debug server $uri")
+          serverSocket.close()
+        } catch {
+          case NonFatal(e) =>
+            logger.warn(
+              s"Could not close debug server listening on [$uri due to: ${e.getMessage}]"
+            )
+        }
       }
     }
+  }
+}
+
+object DebugServer {
+  case class Handler(uri: URI, running: Future[Unit])
+
+  /**
+    * Create the server.
+    * The server must then be started manually
+    *
+    * @param runner The debuggee process
+    * @param logger
+    * @param autoCloseSession If true the session closes itself after receiving terminated event from the debuggee
+    * @param gracePeriod When closed the session waits for the debuggee to terminated gracefully
+    * @param ec
+    * @return a new instance of DebugServer
+    */
+  def apply(
+    runner: DebuggeeRunner,
+    logger: Logger,
+    autoCloseSession: Boolean = false,
+    gracePeriod: Duration = Duration(5, TimeUnit.SECONDS)
+  )(implicit ec: ExecutionContext): DebugServer = {
+    new DebugServer(runner, logger, autoCloseSession, gracePeriod)
+  }
+
+  /**
+    * Create a new server and start it.
+    * The server waits for a connection then starts a session
+    * If the session returns Restarted, the server will wait for a new connection
+    * If the session returns Terminated or Disconnected it stops
+    * 
+    * @param runner The debuggee process
+    * @param logger
+    * @param autoCloseSession If true the session closes itself after receiving terminated event from the debuggee
+    * @param gracePeriod When closed the session waits for the debuggee to terminated gracefully
+    * @param ec
+    * @return The uri and running future of the server
+    */
+  def start(
+    runner: DebuggeeRunner,
+    logger: Logger,
+    autoCloseSession: Boolean = false,
+    gracePeriod: Duration = Duration(2, TimeUnit.SECONDS)
+  )(implicit ec: ExecutionContext): Handler = {
+    val server = new DebugServer(runner, logger, autoCloseSession, gracePeriod)
+    val running = server.start()
+    running.onComplete(_ => server.close())
+    Handler(server.uri, running)
   }
 }

--- a/core/src/main/scala/dap/DebugSessionCallbacks.scala
+++ b/core/src/main/scala/dap/DebugSessionCallbacks.scala
@@ -4,6 +4,6 @@ import java.net.InetSocketAddress
 
 trait DebugSessionCallbacks {
   def onListening(address: InetSocketAddress): Unit
-  def printOut(msg: String): Unit
-  def printErr(msg: String): Unit
+  def printlnOut(msg: String): Unit
+  def printlnErr(msg: String): Unit
 }

--- a/core/src/main/scala/dap/DebuggeeRunner.scala
+++ b/core/src/main/scala/dap/DebuggeeRunner.scala
@@ -3,6 +3,7 @@ package dap
 import java.nio.file.Path
 
 trait DebuggeeRunner {
+  def name: String
   def logger: Logger
   def run(callbacks: DebugSessionCallbacks): CancelableFuture[Unit]
   def classFilesMappedTo(origin: Path, lines: Array[Int], columns: Array[Int]): List[Path]

--- a/core/src/test/scala/dap/MainDebuggeeRunner.scala
+++ b/core/src/test/scala/dap/MainDebuggeeRunner.scala
@@ -19,6 +19,8 @@ import java.io.InputStream
 import java.util.concurrent.atomic.AtomicBoolean
 
 case class MainDebuggeeRunner(source: Path, classpath: String, allClasses: List[Path], mainClass: String, logger: Logger) extends DebuggeeRunner {
+  override def name: String = mainClass
+  
   override def run(callbacks: DebugSessionCallbacks): CancelableFuture[Unit] = {
     val command = Array("java", DebugInterface, "-cp", classpath, mainClass)
     val builder = new ProcessBuilder(command: _*)
@@ -135,10 +137,10 @@ object MainDebuggeeRunner {
         val address = new InetSocketAddress("127.0.0.1", port)
         callbacks.onListening(address)
       } else {
-        callbacks.printOut(line)
+        callbacks.printlnOut(line)
       }
     }
-    startCrawling(process.getErrorStream)(callbacks.printErr)
+    startCrawling(process.getErrorStream)(callbacks.printlnErr)
     
     private val thread = new Thread {
       override def run(): Unit = {

--- a/core/src/test/scala/dap/MockDebuggeeRunner.scala
+++ b/core/src/test/scala/dap/MockDebuggeeRunner.scala
@@ -10,6 +10,7 @@ import scala.language.postfixOps
 class MockDebuggeeRunner() extends DebuggeeRunner {
   var currentProcess: MockCancelableFuture = _
 
+  override def name: String = "mock"
   override def logger: Logger = NoopLogger
 
   override def run(callbacks: DebugSessionCallbacks): CancelableFuture[Unit] = {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,4 +10,5 @@ object Dependencies {
   val utest = "com.lihaoyi" %% "utest" % "0.6.6"
   val scalaCompiler = "org.scala-lang" % "scala-compiler" % scala212
   val io = "org.scala-sbt" %% "io" % "1.4.0"
+  val bloopFrontend = "ch.epfl.scala" %% "bloop-frontend" % "1.4.5"
 }


### PR DESCRIPTION
This PR makes the `scala-debug-adapater` ready for integration with Bloop.

I've created a corresponding PR in Bloop to run the tests: https://github.com/scalacenter/bloop/pull/1444. We should keep it open and run the tests regularly until the core library is ready to be releases.