### PR TITLE
[PoC] Expression evaluation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 .bloop/
 .idea/
 .bsp/
+.metals

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ target/
 .bloop/
 .idea/
 .bsp/
-.metals
+.metals/
+.vscode/

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,8 @@ inThisBuild(
     onLoadMessage := s"Welcome to scala-debug-adapter ${version.value}",
     licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
     developers := Developers.list,
-    scalaVersion := Dependencies.scala212
+    scalaVersion := Dependencies.scala212,
+    version := "1.1.0-SNAPSHOT"
   )
 )
 
@@ -28,6 +29,7 @@ lazy val core = project
       Dependencies.asm,
       Dependencies.asmUtil,
       Dependencies.javaDebug,
+      Dependencies.scalaMeta,
       Dependencies.utest % Test,
       Dependencies.scalaCompiler % Test,
       Dependencies.sbtIo % Test

--- a/core/src/main/scala/ch/epfl/scala/debugadapter/internal/DebugAdapter.scala
+++ b/core/src/main/scala/ch/epfl/scala/debugadapter/internal/DebugAdapter.scala
@@ -1,7 +1,7 @@
 package ch.epfl.scala.debugadapter.internal
 
 import ch.epfl.scala.debugadapter.{DebuggeeRunner, Logger}
-import com.microsoft.java.debug.core.{DebugSettings, IEvaluatableBreakpoint}
+import com.microsoft.java.debug.core.DebugSettings
 import com.microsoft.java.debug.core.adapter._
 import com.microsoft.java.debug.core.protocol.Types
 import com.sun.jdi._
@@ -15,6 +15,7 @@ import java.util.Collections
 import java.util.concurrent.CompletableFuture
 import java.util.function.Consumer
 import scala.collection.mutable
+import scala.concurrent.ExecutionContext
 import scala.util.control.NonFatal
 
 private[debugadapter] object DebugAdapter {
@@ -48,38 +49,6 @@ private[debugadapter] object DebugAdapter {
         line: Int,
         column: Int
     ): util.List[Types.CompletionItem] = Collections.emptyList()
-  }
-
-  object EvaluationProvider extends IEvaluationProvider {
-    override def isInEvaluation(thread: ThreadReference): Boolean = false
-
-    override def evaluate(
-        expression: String,
-        thread: ThreadReference,
-        depth: Int
-    ): CompletableFuture[Value] = ???
-
-    override def evaluate(
-        expression: String,
-        thisContext: ObjectReference,
-        thread: ThreadReference
-    ): CompletableFuture[Value] = ???
-
-    override def evaluateForBreakpoint(
-        breakpoint: IEvaluatableBreakpoint,
-        thread: ThreadReference
-    ): CompletableFuture[Value] = ???
-
-    override def invokeMethod(
-        thisContext: ObjectReference,
-        methodName: String,
-        methodSignature: String,
-        args: Array[Value],
-        thread: ThreadReference,
-        invokeSuper: Boolean
-    ): CompletableFuture[Value] = ???
-
-    override def clearState(thread: ThreadReference): Unit = {}
   }
 
   object HotCodeReplaceProvider extends IHotCodeReplaceProvider {

--- a/core/src/main/scala/ch/epfl/scala/debugadapter/internal/EvaluationProvider.scala
+++ b/core/src/main/scala/ch/epfl/scala/debugadapter/internal/EvaluationProvider.scala
@@ -1,0 +1,212 @@
+package ch.epfl.scala.debugadapter.internal
+
+import com.microsoft.java.debug.core.IEvaluatableBreakpoint
+import com.microsoft.java.debug.core.adapter.IEvaluationProvider
+import com.sun.jdi.{DoubleValue, Field, FloatValue, LocalVariable, LongValue, Method, ObjectReference, PrimitiveValue, StackFrame, ThreadReference, Value, VirtualMachine}
+
+import java.util.concurrent.CompletableFuture
+import scala.jdk.CollectionConverters._
+import scala.meta.parsers.Parsed
+import scala.meta.{Stat, Term, _}
+import scala.util.Try
+
+object EvaluationProvider extends IEvaluationProvider {
+  override def isInEvaluation(thread: ThreadReference): Boolean = false
+
+  // Currently, only single expression is supported
+  override def evaluate(
+      expression: String,
+      thread: ThreadReference,
+      depth: Int
+  ): CompletableFuture[Value] = {
+    val frame = thread.frames().get(depth)
+    val result = expression.parse[Stat] match {
+      case Parsed.Success(tree) => evaluate(tree, frame, thread)
+      case Parsed.Error(_, msg, _) => Left(msg)
+    }
+    CompletableFuture.completedFuture(result.fold(error => thread.virtualMachine().mirrorOf(error), identity))
+  }
+
+  override def evaluate(
+      expression: String,
+      thisContext: ObjectReference,
+      thread: ThreadReference
+  ): CompletableFuture[Value] = ???
+
+  override def evaluateForBreakpoint(
+      breakpoint: IEvaluatableBreakpoint,
+      thread: ThreadReference
+  ): CompletableFuture[Value] = ???
+
+  override def invokeMethod(
+      thisContext: ObjectReference,
+      methodName: String,
+      methodSignature: String,
+      args: Array[Value],
+      thread: ThreadReference,
+      invokeSuper: Boolean
+  ): CompletableFuture[Value] = ???
+
+  override def clearState(thread: ThreadReference): Unit = {}
+
+  private def evaluate(tree: Stat, frame: StackFrame, thread: ThreadReference): Either[String, Value] = {
+    tree match {
+      case _: Lit.Unit =>
+        Right(frame.virtualMachine().mirrorOfVoid())
+      case lit: Lit.Boolean =>
+        Right(frame.virtualMachine().mirrorOf(lit.value))
+      case lit: Lit.Byte =>
+        Right(frame.virtualMachine().mirrorOf(lit.value))
+      case lit: Lit.Char =>
+        Right(frame.virtualMachine().mirrorOf(lit.value))
+      case lit: Lit.Double =>
+        Right(frame.virtualMachine().mirrorOf(lit.syntax.toDouble))
+      case lit: Lit.Float =>
+        Right(frame.virtualMachine().mirrorOf(lit.syntax.toFloat))
+      case lit: Lit.Int =>
+        Right(frame.virtualMachine().mirrorOf(lit.value))
+      case lit: Lit.Long =>
+        Right(frame.virtualMachine().mirrorOf(lit.value))
+      case lit: Lit.Short =>
+        Right(frame.virtualMachine().mirrorOf(lit.value))
+      case lit: Lit.String =>
+        Right(frame.virtualMachine().mirrorOf(lit.value))
+      case term: Term.Name =>
+        value(term, frame, thread).toRight(s"`${term.value}` doesn't exist")
+      case Term.Select(qual, name) =>
+        val result = for {
+          qualVal <- evaluate(qual, frame, thread).toOption
+          selected <- select(name, qualVal, thread)
+        } yield selected
+        result.toRight(s"`${name.value}` doesn't exist")
+      case term: Term.Apply =>
+        for {
+          args <- evaluateAll(term.args, frame, thread)
+          fun <- evaluateFun(term.fun, args, frame, thread)
+          result <- invoke(fun, args, thread)
+        } yield result
+      case term: Term.ApplyInfix =>
+        for {
+          lhs <- evaluate(term.lhs, frame, thread)
+          rhs <- evaluate(term.args.head, frame, thread)
+          result <- evaluateOp(lhs, rhs, term.op.value, thread.virtualMachine())
+        } yield result
+      case _ =>
+        Left("unsupported operation")
+    }
+  }
+
+  private def evaluateAll(terms: List[Term], frame: StackFrame, thread: ThreadReference) =
+    traverse(terms.map(term => evaluate(term, frame, thread)))
+
+  private def evaluateFun(term: Term, args: List[Value], frame: StackFrame, thread: ThreadReference): Either[String, Fun] = term match {
+    case term: Term.Name =>
+      val objRef = frame.thisObject()
+      methodByArgs(term, objRef, args)
+        .map(method => Fun(objRef, method))
+        .toRight(s"unable to invoke `${term.value}`")
+    case term: Term.Select =>
+      evaluate(term.qual, frame, thread) match {
+        case Right(objRef: ObjectReference) =>
+          methodByArgs(term.name, objRef, args)
+            .map(method => Fun(objRef, method))
+            .toRight(s"unable to invoke `${term.name.value}`")
+        case Right(_) => Left(s"unable to invoke `${term.name.value}`")
+        case Left(msg) => Left(msg)
+      }
+    case _ => Left("unsupported operation")
+  }
+
+  private def evaluateOp(lhs: Value, rhs: Value, op: String, vm: VirtualMachine): Either[String, Value] = (lhs, rhs) match {
+    case (x: PrimitiveValue, y: PrimitiveValue) => (x, y) match {
+        case (_: DoubleValue, _) | (_, _: DoubleValue) =>
+          evaluateFractionals(x.doubleValue(), y.doubleValue(), op).map(vm.mirrorOf)
+        case (_: FloatValue, _) | (_, _: FloatValue) =>
+          evaluateFractionals(x.floatValue(), y.floatValue(), op).map(vm.mirrorOf)
+        case (_: LongValue, _) | (_, _: LongValue) =>
+          evaluateIntegrals(x.longValue(), y.longValue(), op).map(vm.mirrorOf)
+        case (_, _) | (_, _) =>
+          evaluateIntegrals(x.intValue(), y.intValue(), op).map(vm.mirrorOf)
+        case _ => Left ("unsupported operation")
+      }
+    case _ => Left("unable to evaluate non-primitives")
+  }
+
+  private def evaluateIntegrals[T](
+      x: T,
+      y: T,
+      op: String
+  )(implicit integral: Integral[T]): Either[String, T] = op match {
+    case "+" => Right(integral.plus(x, y))
+    case "-" => Right(integral.minus(x, y))
+    case "*" => Right(integral.times(x, y))
+    case "/" => Right(integral.quot(x, y))
+    case _ => Left("fail")
+  }
+
+  private def evaluateFractionals[T](
+      x: T,
+      y: T,
+      op: String
+  )(implicit fractional: Fractional[T]): Either[String, T] = op match {
+    case "+" => Right(fractional.plus(x, y))
+    case "-" => Right(fractional.minus(x, y))
+    case "*" => Right(fractional.times(x, y))
+    case "/" => Right(fractional.div(x, y))
+    case _ => Left("fail")
+  }
+
+  private def invoke(fun: Fun, args: List[Value], thread: ThreadReference): Either[String, Value] =
+    Try(fun.objRef.invokeMethod(thread, fun.method, args.asJava, ObjectReference.INVOKE_SINGLE_THREADED))
+      .toOption
+      .toRight(s"unable to invoke `${fun.method.name()}`")
+
+  private def value(name: Term.Name, frame: StackFrame, thread: ThreadReference): Option[Value] =
+    variable(name, frame)
+      .flatMap(variable => variableValue(variable, frame))
+      .orElse(select(name, frame.thisObject(), thread))
+
+  private def select(name: Term.Name, value: Value, thread: ThreadReference): Option[Value] = value match {
+    case objRef: ObjectReference =>
+      field(name, objRef)
+        .flatMap(field => fieldValue(field, objRef))
+        .orElse(method(name, objRef).flatMap(method => invoke(Fun(objRef, method), List(), thread).toOption))
+    case _ => None
+  }
+
+  private def variable(name: Term.Name, frame: StackFrame): Option[LocalVariable] =
+    Try(frame.visibleVariableByName(name.value))
+      .filter(_ != null)
+      .toOption
+
+  private def variableValue(localVariable: LocalVariable, frame: StackFrame): Option[Value] =
+    Try(frame.getValue(localVariable)).toOption
+
+  private def field(name: Term.Name, objRef: ObjectReference): Option[Field] =
+    Try(objRef.referenceType().fieldByName(name.value)).toOption.filter(_ != null)
+
+  private def fieldValue(field: Field, objRef: ObjectReference): Option[Value] =
+    Try(objRef.getValue(field)).toOption
+
+  private def method(name: Term.Name, objRef: ObjectReference): Option[Method] =
+    Try(objRef.referenceType().methodsByName(name.value).asScala.headOption).toOption.flatten
+
+  private def methodByArgs(name: Term.Name, objRef: ObjectReference, args: List[Value]): Option[Method] = {
+    val argsSignature = s"(${args.map(_.`type`().signature()).mkString})"
+    Try(objRef.referenceType().methodsByName(name.value).asScala.find(_.signature().startsWith(argsSignature))).toOption.flatten
+  }
+
+  private def traverse[A, B](eithers: List[Either[A, B]]): Either[A, List[B]] = {
+    val builder = List.newBuilder[B]
+    val it = eithers.iterator
+
+    while (it.hasNext) it.next() match {
+      case Left(a) => return Left(a)
+      case Right(b) => builder += b
+    }
+
+    Right(builder.result())
+  }
+
+  case class Fun(objRef: ObjectReference, method: Method)
+}

--- a/core/src/test/resources/EvaluateTest.scala
+++ b/core/src/test/resources/EvaluateTest.scala
@@ -1,0 +1,26 @@
+object EvaluateTest {
+  val a = 1
+  val b = 2
+
+  def main(args: Array[String]): Unit = {
+    val c = Num(9)
+    val d = Num(5)
+    val e = 3
+    val f = 4
+    println(a + b)
+    println(c.add(d))
+    println(add(e, f))
+  }
+
+  def add(x: Int, y: Int): Int = x + y
+
+  def add(x: Double, y: Double): Double = x + y
+
+  def add(x: Num, y: Num): Int = x.add(y).value
+
+  case class Num(value: Int) {
+    def add(num: Num): Num = {
+      Num(value + num.value)
+    }
+  }
+}

--- a/core/src/test/scala/ch/epfl/scala/debugadapter/MainDebuggeeRunner.scala
+++ b/core/src/test/scala/ch/epfl/scala/debugadapter/MainDebuggeeRunner.scala
@@ -60,6 +60,11 @@ object MainDebuggeeRunner {
     compileJava(src, "BreakpointTest", dest)
   }
 
+  def evaluateTest(dest: File): MainDebuggeeRunner = {
+    val src = getResource("/EvaluateTest.scala")
+    compileScala(src, "EvaluateTest", dest)
+  }
+
   private def getResource(name: String): Path =
     Paths.get(getClass.getResource(name).toURI)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,6 +7,7 @@ object Dependencies {
   val asm = "org.ow2.asm" % "asm" % asmVersion
   val asmUtil = "org.ow2.asm" % "asm-util" % asmVersion
   val javaDebug = "ch.epfl.scala" % "com-microsoft-java-debug-core" % "0.21.0+1-7f1080f1"
+  val scalaMeta = "org.scalameta" %% "scalameta" % "4.4.8"
   val utest = "com.lihaoyi" %% "utest" % "0.6.6"
   val scalaCompiler = "org.scala-lang" % "scala-compiler" % scala212
   val sbtIo = "org.scala-sbt" %% "io" % "1.4.0"

--- a/test-client/src/main/scala/ch/epfl/scala/debugadapter/testing/TestDebugClient.scala
+++ b/test-client/src/main/scala/ch/epfl/scala/debugadapter/testing/TestDebugClient.scala
@@ -105,6 +105,16 @@ class TestDebugClient(socket: Socket, timeout: Duration)(implicit ec: ExecutionC
     getBody[VariablesResponseBody](response).variables
   }
 
+  def evaluate(expression: String, frameId: Int): String = {
+    val args = new EvaluateArguments()
+    args.expression = expression
+    args.frameId = frameId
+    args.context = "repl"
+    val request = createRequest(Command.EVALUATE, args)
+    val response = sendRequest(request, timeout)
+    getBody[EvaluateResponseBody](response).result
+  }
+
   def disconnect(restart: Boolean): Messages.Response = {
     val args = new DisconnectArguments()
     args.restart = restart


### PR DESCRIPTION
This PR is a basic proof of concept of the expression evaluation. It's based on the idea described here: https://github.com/scalacenter/scala-debug-adapter/issues/34#issuecomment-781333289. 

Implemented features:
- basic arithmetic operations on primitives, variables, and fields,
- invoking (overloaded) methods,
- accessing values,
- basic error handling.

Implemented functionality is obviously far from being complete. Some features can be added rather easily (e.g. better support for primitives and operations on them). However, AST seems to not be enough to implement features like implicits, imports, or creating new instances of objects. It would probably require reimplementing the logic that is already implemented in the compiler. Even some basic operations like `-1.abs` are currently not supported because JDI doesn't provide an access to `Int` object but only to its primitive value. Also, it seems that we don't have access to a `Predef` object which contains some useful functions. There are probably other issues that I didn't describe or haven't discovered yet.

An example of how it works in VSCode:
![Screenshot from 2021-03-04 11-05-06](https://user-images.githubusercontent.com/6402694/109947413-938a6480-7cd9-11eb-9e2d-f860dfc8445d.png)
