### PR TITLE
Environment variables in debug session

### DIFF
--- a/sbt/plugin/src/main/contraband/dap.contra
+++ b/sbt/plugin/src/main/contraband/dap.contra
@@ -18,3 +18,17 @@ type DebugSessionParams {
   ## A language-agnostic JSON object interpreted by the server.
   data: sjsonnew.shaded.scalajson.ast.unsafe.JValue
 }
+
+type ScalaMainClass {
+  ## The main class to run.
+  class: String!
+
+  ## The user arguments to the main entrypoint.
+  arguments: [String]
+
+  ## The jvm options for the application.
+  jvmOptions: [String]
+
+  ## Additional environment variables for the application.
+  environmentVariables: [String]
+}

--- a/sbt/plugin/src/main/scala/ch/epfl/scala/debugadapter/sbtplugin/DebugAdapterPlugin.scala
+++ b/sbt/plugin/src/main/scala/ch/epfl/scala/debugadapter/sbtplugin/DebugAdapterPlugin.scala
@@ -7,8 +7,7 @@ import ch.epfl.scala.debugadapter.DebuggeeRunner
 
 import sbt.Tests._
 import sbt._
-import sbt.internal.bsp._
-import sbt.internal.bsp.codec.JsonProtocol._
+import sbt.internal.bsp.{ScalaMainClass => _, _}
 import sbt.internal.protocol.JsonRpcRequestMessage
 import sbt.internal.server.{ServerHandler, ServerIntent}
 import sbt.internal.util.complete.{Parser, Parsers}
@@ -185,7 +184,12 @@ object DebugAdapterPlugin extends sbt.AutoPlugin {
         workingDirectory = Option(workingDirectory),
         runJVMOptions = params.jvmOptions,
         connectInput = false,
-        envVars = envVars
+        envVars = envVars ++ params.environmentVariables
+          .flatMap(_.split("=", 2).toList match {
+            case key :: value :: Nil => Some(key -> value)
+            case _                   => None
+          })
+          .toMap
       )
 
       new MainClassRunner(


### PR DESCRIPTION
Related to changes in https://github.com/sbt/sbt/pull/6397 and described in https://github.com/sbt/sbt/issues/6396

Adds support for the new field in `ScalaMainClass`. Uses copy of contraband schema to not depend on newer version of sbt. Conflicting imports are shaded with one defined in this project.