### PR TITLE
Enable show static variables

### DIFF
--- a/core/src/main/scala/ch/epfl/scala/debugadapter/internal/DebugAdapter.scala
+++ b/core/src/main/scala/ch/epfl/scala/debugadapter/internal/DebugAdapter.scala
@@ -31,6 +31,12 @@ private[debugadapter] object DebugAdapter {
    */
   DebugSettings.getCurrent.showToString = false
 
+    /**
+    * Since Scala 2.13, object fields are represented by static fields in JVM byte code.
+    * See https://github.com/scala/scala/pull/7270
+    */
+  DebugSettings.getCurrent.showStaticVariables = true
+
   def context(runner: DebuggeeRunner, logger: Logger): IProviderContext = {
     val context = new ProviderContext
     context.registerProvider(classOf[IHotCodeReplaceProvider], HotCodeReplaceProvider)


### PR DESCRIPTION
Set `showStaticFields` setting to true so that object fields are shown in Scala 2.13 and Scala 3.