### PR TITLE
Reduce the flakiness of the tests

### DIFF
--- a/core/src/test/scala/ch/epfl/scala/debugadapter/DebugServerSpec.scala
+++ b/core/src/test/scala/ch/epfl/scala/debugadapter/DebugServerSpec.scala
@@ -148,7 +148,7 @@ object DebugServerSpec extends TestSuite {
         server.connect()
         client.initialize()
         assert(client.launch().success)
-        client.initialized
+        client.initialized()
         client.configurationDone()
       } finally {
         server.close()
@@ -169,7 +169,7 @@ object DebugServerSpec extends TestSuite {
         client.configurationDone()
         // give some time for the debuggee to terminate gracefully
         server.close()
-        client.terminated
+        client.terminated()
       } finally {
         server.close() // in case test fails
         client.close()
@@ -207,10 +207,10 @@ object DebugServerSpec extends TestSuite {
         client.launch()
         client.configurationDone()
         // the debuggee should exits immediately
-        val exitedEvent = client.exited
+        val exitedEvent = client.exited()
         assert(exitedEvent.exitCode == 0)
 
-        client.terminated
+        client.terminated()
       } finally {
         server.close()
         client.close()
@@ -229,13 +229,13 @@ object DebugServerSpec extends TestSuite {
         client.launch()
         client.configurationDone()
         // the debuggee should exits immediately
-        val exitedEvent = client.exited
+        val exitedEvent = client.exited()
 
         // surprisingly, the java debug implementation always set exitCode to 0
         // https://github.com/microsoft/java-debug/blob/211c47aabec6d47d8393ec39b6fdf0cbfcd8dbb0/com.microsoft.java.debug.core/src/main/java/com/microsoft/java/debug/core/adapter/handler/ConfigurationDoneRequestHandler.java#L84
         assert(exitedEvent.exitCode == 0)
 
-        client.terminated
+        client.terminated()
       } finally {
         server.close()
         client.close()
@@ -258,28 +258,28 @@ object DebugServerSpec extends TestSuite {
         assert(breakpoints.forall(_.verified))
 
         client.configurationDone()
-        val stopped1 = client.stopped
+        val stopped1 = client.stopped()
         val threadId = stopped1.threadId
         assert(stopped1.reason == "breakpoint")
 
         client.continue(threadId)
-        val stopped2 = client.stopped
+        val stopped2 = client.stopped()
         assert(stopped2.reason == "breakpoint")
         assert(stopped2.threadId == threadId)
 
         client.continue(threadId)
-        val stopped3 = client.stopped
+        val stopped3 = client.stopped()
         assert(stopped3.reason == "breakpoint")
         assert(stopped3.threadId == threadId)
 
         client.continue(threadId)
-        val stopped4 = client.stopped
+        val stopped4 = client.stopped()
         assert(stopped4.reason == "breakpoint")
         assert(stopped4.threadId == threadId)
 
         client.continue(threadId)
-        client.exited
-        client.terminated
+        client.exited()
+        client.terminated()
       } finally {
         server.close()
         client.close()

--- a/core/src/test/scala/ch/epfl/scala/debugadapter/DebugServerSpec.scala
+++ b/core/src/test/scala/ch/epfl/scala/debugadapter/DebugServerSpec.scala
@@ -17,6 +17,12 @@ object DebugServerSpec extends TestSuite {
   val executorService = Executors.newFixedThreadPool(1)
   implicit val ec = ExecutionContext.fromExecutorService(executorService)
 
+  private val connectionFailedMessages = Array(
+    "(Connection refused)",
+    "(Connection Failed)",
+    "(connect failed)"
+  )
+
   def tests: Tests = Tests {
     "should prevent connection when closed" - {
       val runner = new MockDebuggeeRunner()
@@ -30,11 +36,7 @@ object DebugServerSpec extends TestSuite {
         case _: ConnectException => ()
         case e: SocketException =>
           val msg = e.getMessage
-          assert(
-            msg.endsWith("(Connection refused)") || msg.endsWith(
-              "(Connection Failed)"
-            )
-          )
+          assert(connectionFailedMessages.exists(msg.endsWith))
       }
     }
 
@@ -345,11 +347,7 @@ object DebugServerSpec extends TestSuite {
           case _: SocketTimeoutException => ()
           case e: SocketException =>
             val msg = e.getMessage
-            assert(
-              msg.endsWith("(Connection refused)") || msg.endsWith(
-                "(Connection Failed)"
-              )
-            )
+            assert(connectionFailedMessages.exists(msg.endsWith))
         } finally {
           if (client2 != null) client2.close()
         }

--- a/core/src/test/scala/ch/epfl/scala/debugadapter/ExpressionEvaluatorSpec.scala
+++ b/core/src/test/scala/ch/epfl/scala/debugadapter/ExpressionEvaluatorSpec.scala
@@ -354,7 +354,7 @@ object ExpressionEvaluatorSpec extends TestSuite {
       assert(breakpoints.forall(_.verified))
       client.configurationDone()
 
-      val stopped = client.stopped
+      val stopped = client.stopped()
       val threadId = stopped.threadId
       assert(stopped.reason == "breakpoint")
 
@@ -365,8 +365,8 @@ object ExpressionEvaluatorSpec extends TestSuite {
       assert(assertion(result))
 
       client.continue(threadId)
-      client.exited
-      client.terminated
+      client.exited()
+      client.terminated()
     } finally {
       server.close()
       client.close()

--- a/core/src/test/scala/ch/epfl/scala/debugadapter/MoreScala3DebugTest.scala
+++ b/core/src/test/scala/ch/epfl/scala/debugadapter/MoreScala3DebugTest.scala
@@ -28,18 +28,18 @@ object MoreScala3DebugTest extends TestSuite {
         assert(breakpoints.forall(_.verified))
 
         client.configurationDone()
-        val stop = client.stopped
+        val stop = client.stopped()
         val threadId = stop.threadId
 
         client.continue(threadId)
-        client.stopped
+        client.stopped()
 
         client.continue(threadId)
-        client.stopped
+        client.stopped()
 
         client.continue(threadId)
-        client.exited
-        client.terminated
+        client.exited()
+        client.terminated()
       } finally {
         server.close()
         client.close()
@@ -62,18 +62,18 @@ object MoreScala3DebugTest extends TestSuite {
         assert(breakpoints.forall(_.verified))
 
         client.configurationDone()
-        val stop = client.stopped
+        val stop = client.stopped()
         val threadId = stop.threadId
 
         client.continue(threadId)
-        client.stopped
+        client.stopped()
 
         client.continue(threadId)
-        client.stopped
+        client.stopped()
 
         client.continue(threadId)
-        client.exited
-        client.terminated
+        client.exited()
+        client.terminated()
       } finally {
         server.close()
         client.close()

--- a/core/src/test/scala/ch/epfl/scala/debugadapter/ScalaDebugTestSuite.scala
+++ b/core/src/test/scala/ch/epfl/scala/debugadapter/ScalaDebugTestSuite.scala
@@ -33,33 +33,33 @@ class ScalaDebugTestSuite(scalaVersion: ScalaVersion) extends TestSuite {
         assert(breakpoints.forall(_.verified))
 
         client.configurationDone()
-        val stopped1 = client.stopped
+        val stopped1 = client.stopped()
         val threadId = stopped1.threadId
         assert(stopped1.reason == "breakpoint")
 
         client.continue(threadId)
-        val stopped2 = client.stopped
+        val stopped2 = client.stopped()
         assert(stopped2.reason == "breakpoint")
         assert(stopped2.threadId == threadId)
 
         client.continue(threadId)
-        val stopped3 = client.stopped
+        val stopped3 = client.stopped()
         assert(stopped3.reason == "breakpoint")
         assert(stopped3.threadId == threadId)
 
         client.continue(threadId)
-        val stopped4 = client.stopped
+        val stopped4 = client.stopped()
         assert(stopped4.reason == "breakpoint")
         assert(stopped4.threadId == threadId)
 
         client.continue(threadId)
-        val stopped5 = client.stopped
+        val stopped5 = client.stopped()
         assert(stopped5.reason == "breakpoint")
         assert(stopped5.threadId == threadId)
 
         client.continue(threadId)
-        client.exited
-        client.terminated
+        client.exited()
+        client.terminated()
       } finally {
         server.close()
         client.close()
@@ -77,23 +77,24 @@ class ScalaDebugTestSuite(scalaVersion: ScalaVersion) extends TestSuite {
         client.initialize()
         client.launch()
 
-        val breakpoints = client.setBreakpoints(runner.mainClass, Array(5, 9))
+        val breakpoints =
+          client.setBreakpointsInClass(runner.mainClass, Array(5, 9))
         assert(breakpoints.size == 2)
         assert(breakpoints.forall(_.verified))
 
         client.configurationDone()
-        val stopped1 = client.stopped
+        val stopped1 = client.stopped()
         val threadId = stopped1.threadId
         assert(stopped1.reason == "breakpoint")
 
         client.continue(threadId)
-        val stopped2 = client.stopped
+        val stopped2 = client.stopped()
         assert(stopped2.reason == "breakpoint")
         assert(stopped2.threadId == threadId)
 
         client.continue(threadId)
-        client.exited
-        client.terminated
+        client.exited()
+        client.terminated()
       } finally {
         server.close()
         client.close()
@@ -113,7 +114,7 @@ class ScalaDebugTestSuite(scalaVersion: ScalaVersion) extends TestSuite {
         client.setBreakpoints(runner.source, Array(7))
         client.configurationDone()
 
-        val stopped = client.stopped
+        val stopped = client.stopped()
         val stackTrace = client.stackTrace(stopped.threadId)
         assert(stackTrace.totalFrames == 2)
 
@@ -130,8 +131,8 @@ class ScalaDebugTestSuite(scalaVersion: ScalaVersion) extends TestSuite {
         }
 
         client.continue(stopped.threadId)
-        client.exited
-        client.terminated
+        client.exited()
+        client.terminated()
       } finally {
         server.close()
         client.close()
@@ -151,7 +152,7 @@ class ScalaDebugTestSuite(scalaVersion: ScalaVersion) extends TestSuite {
         client.setBreakpoints(runner.source, Array(7))
         client.configurationDone()
 
-        val stopped = client.stopped
+        val stopped = client.stopped()
         val stackTrace = client.stackTrace(stopped.threadId)
         assert(stackTrace.totalFrames == 2)
 
@@ -176,8 +177,8 @@ class ScalaDebugTestSuite(scalaVersion: ScalaVersion) extends TestSuite {
         }
 
         client.continue(stopped.threadId)
-        client.exited
-        client.terminated
+        client.exited()
+        client.terminated()
       } finally {
         server.close()
         client.close()

--- a/sbt/plugin/src/sbt-test/debug-session/attach/build.sbt
+++ b/sbt/plugin/src/sbt-test/debug-session/attach/build.sbt
@@ -24,17 +24,17 @@ checkDebugSession := {
 
     client.configurationDone()
 
-    val threadId = client.stopped.threadId
+    val threadId = client.stopped().threadId
 
     client.continue(threadId)
-    client.stopped
+    client.stopped()
 
     client.continue(threadId)
-    client.stopped
+    client.stopped()
 
     client.continue(threadId)
-    client.exited
-    client.terminated
+    client.exited()
+    client.terminated()
   } finally {
     client.close()
   }

--- a/sbt/plugin/src/sbt-test/debug-session/integration-test-suite/build.sbt
+++ b/sbt/plugin/src/sbt-test/debug-session/integration-test-suite/build.sbt
@@ -36,17 +36,17 @@ def checkDebugSessionTask = Def.inputTask {
 
     client.configurationDone()
 
-    val threadId = client.stopped.threadId
+    val threadId = client.stopped().threadId
 
     client.continue(threadId)
-    client.stopped
+    client.stopped()
 
     client.continue(threadId)
-    client.stopped
+    client.stopped()
 
     client.continue(threadId)
-    client.exited
-    client.terminated
+    client.exited()
+    client.terminated()
   } finally {
     client.close()
   }

--- a/sbt/plugin/src/sbt-test/debug-session/main-class-scala3/build.sbt
+++ b/sbt/plugin/src/sbt-test/debug-session/main-class-scala3/build.sbt
@@ -21,17 +21,17 @@ checkDebugSession := {
 
     client.configurationDone()
 
-    val threadId = client.stopped.threadId
+    val threadId = client.stopped().threadId
 
     client.continue(threadId)
-    client.stopped
+    client.stopped()
 
     client.continue(threadId)
-    client.stopped
+    client.stopped()
 
     client.continue(threadId)
-    client.exited
-    client.terminated
+    client.exited()
+    client.terminated()
   } finally {
     client.close()
   }

--- a/sbt/plugin/src/sbt-test/debug-session/main-class/build.sbt
+++ b/sbt/plugin/src/sbt-test/debug-session/main-class/build.sbt
@@ -21,17 +21,17 @@ checkDebugSession := {
 
     client.configurationDone()
 
-    val threadId = client.stopped.threadId
+    val threadId = client.stopped().threadId
 
     client.continue(threadId)
-    client.stopped
+    client.stopped()
 
     client.continue(threadId)
-    client.stopped
+    client.stopped()
 
     client.continue(threadId)
-    client.exited
-    client.terminated
+    client.exited()
+    client.terminated()
   } finally {
     client.close()
   }

--- a/sbt/plugin/src/sbt-test/debug-session/step-into-jdk/build.sbt
+++ b/sbt/plugin/src/sbt-test/debug-session/step-into-jdk/build.sbt
@@ -28,18 +28,18 @@ checkDebugSession := {
 
     client.configurationDone()
 
-    val threadId = client.stopped.threadId
+    val threadId = client.stopped().threadId
 
     client.stepIn(threadId)
-    client.stopped
+    client.stopped()
 
     val frame = client.stackTrace(threadId).stackFrames.head
     assert(frame.source.path.endsWith("/java/io/PrintStream.java"))
 
     client.continue(threadId)
 
-    client.exited
-    client.terminated
+    client.exited()
+    client.terminated()
   } finally {
     client.close()
   }

--- a/sbt/plugin/src/sbt-test/debug-session/test-suite/build.sbt
+++ b/sbt/plugin/src/sbt-test/debug-session/test-suite/build.sbt
@@ -25,17 +25,17 @@ checkDebugSession := {
 
     client.configurationDone()
 
-    val threadId = client.stopped.threadId
+    val threadId = client.stopped().threadId
 
     client.continue(threadId)
-    client.stopped
+    client.stopped()
 
     client.continue(threadId)
-    client.stopped
+    client.stopped()
 
     client.continue(threadId)
-    client.exited
-    client.terminated
+    client.exited()
+    client.terminated()
   } finally {
     client.close()
   }


### PR DESCRIPTION
- Handle `(connect failed)` message
- Add more fine-grained control on the timeouts

The value of the timeouts can be tweaked later on each request if needed (for example, `evaluate` takes more time than  `setBreakpoints`)