### PR TITLE
Test when expression compiler cannot be resolved

### DIFF
--- a/core/src/test/scala/ch/epfl/scala/debugadapter/ExpressionEvaluatorSpec.scala
+++ b/core/src/test/scala/ch/epfl/scala/debugadapter/ExpressionEvaluatorSpec.scala
@@ -8,6 +8,7 @@ import java.io.File
 import java.util.concurrent.Executors
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
+import com.microsoft.java.debug.core.protocol.Types.Message
 
 object ExpressionEvaluatorSpec extends TestSuite {
   // the server needs only one thread for delayed responses of the launch and configurationDone requests
@@ -24,7 +25,9 @@ object ExpressionEvaluatorSpec extends TestSuite {
           |  }
           |}
           |""".stripMargin
-      assertEvaluation(source, "EvaluateTest", 3, "1 + 2", _.toInt == 3)
+      assertEvaluation(source, "EvaluateTest", 3, "1 + 2")(
+        _.exists(_.toInt == 3)
+      )
     }
 
     "should evaluate expression with local variables" - {
@@ -37,7 +40,9 @@ object ExpressionEvaluatorSpec extends TestSuite {
           |  }
           |}
           |""".stripMargin
-      assertEvaluation(source, "EvaluateTest", 5, "x1 + x2", _.toDouble == 3.3)
+      assertEvaluation(source, "EvaluateTest", 5, "x1 + x2")(
+        _.exists(_.toDouble == 3.3)
+      )
     }
 
     "should evaluate expression with object's public fields" - {
@@ -55,8 +60,12 @@ object ExpressionEvaluatorSpec extends TestSuite {
           |  }
           |}
           |""".stripMargin
-      assertEvaluation(source, "EvaluateTest", 10, "x1 + x2", _.toDouble == 3.3)
-      assertEvaluation(source, "EvaluateTest", 10, "A.x1", _ == "\"x1\"")
+      assertEvaluation(source, "EvaluateTest", 10, "x1 + x2")(
+        _.exists(_.toDouble == 3.3)
+      )
+      assertEvaluation(source, "EvaluateTest", 10, "A.x1")(
+        _.exists(_ == "\"x1\"")
+      )
     }
 
     "should evaluate expression with object's private fields" - {
@@ -70,7 +79,9 @@ object ExpressionEvaluatorSpec extends TestSuite {
           |  }
           |}
           |""".stripMargin
-      assertEvaluation(source, "EvaluateTest", 6, "x1 + x2", _.toDouble == 3.3)
+      assertEvaluation(source, "EvaluateTest", 6, "x1 + x2")(
+        _.exists(_.toDouble == 3.3)
+      )
     }
 
     "should evaluate expression with class's public fields" - {
@@ -89,8 +100,10 @@ object ExpressionEvaluatorSpec extends TestSuite {
           |  }
           |}
           |""".stripMargin
-      assertEvaluation(source, "EvaluateTest", 5, "x1", _ == "\"x1\"")
-      assertEvaluation(source, "EvaluateTest", 11, "new A().x1", _ == "\"x1\"")
+      assertEvaluation(source, "EvaluateTest", 5, "x1")(_.exists(_ == "\"x1\""))
+      assertEvaluation(source, "EvaluateTest", 11, "new A().x1")(
+        _.exists(_ == "\"x1\"")
+      )
     }
 
     "should evaluate expression with class's private fields" - {
@@ -109,7 +122,7 @@ object ExpressionEvaluatorSpec extends TestSuite {
           |  }
           |}
           |""".stripMargin
-      assertEvaluation(source, "EvaluateTest", 5, "x1", _ == "\"x1\"")
+      assertEvaluation(source, "EvaluateTest", 5, "x1")(_.exists(_ == "\"x1\""))
     }
 
     "should evaluate expression with inner class's public fields" - {
@@ -132,8 +145,10 @@ object ExpressionEvaluatorSpec extends TestSuite {
           |  }
           |}
           |""".stripMargin
-      assertEvaluation(source, "EvaluateTest", 6, "x1", _ == "\"x1\"")
-      assertEvaluation(source, "EvaluateTest", 15, "b.x1", _ == "\"x1\"")
+      assertEvaluation(source, "EvaluateTest", 6, "x1")(_.exists(_ == "\"x1\""))
+      assertEvaluation(source, "EvaluateTest", 15, "b.x1")(
+        _.exists(_ == "\"x1\"")
+      )
     }
 
     "should evaluate expression with inner class's private fields" - {
@@ -156,7 +171,7 @@ object ExpressionEvaluatorSpec extends TestSuite {
           |  }
           |}
           |""".stripMargin
-      assertEvaluation(source, "EvaluateTest", 6, "x1", _ == "\"x1\"")
+      assertEvaluation(source, "EvaluateTest", 6, "x1")(_.exists(_ == "\"x1\""))
     }
 
     "should evaluate expression with outer class's public fields" - {
@@ -178,7 +193,7 @@ object ExpressionEvaluatorSpec extends TestSuite {
           |  }
           |}
           |""".stripMargin
-      assertEvaluation(source, "EvaluateTest", 5, "x1", _ == "\"x1\"")
+      assertEvaluation(source, "EvaluateTest", 5, "x1")(_.exists(_ == "\"x1\""))
     }
 
     "should evaluate expression with a public method call" - {
@@ -203,7 +218,9 @@ object ExpressionEvaluatorSpec extends TestSuite {
           |}
           |""".stripMargin
 
-      assertEvaluation(source, "EvaluateTest", 5, "m2()", _.toInt == 1)
+      assertEvaluation(source, "EvaluateTest", 5, "m2()")(
+        _.exists(_.toInt == 1)
+      )
     }
 
     "should evaluate expression with inner class's overridden fields" - {
@@ -227,7 +244,9 @@ object ExpressionEvaluatorSpec extends TestSuite {
           |  }
           |}
           |""".stripMargin
-      assertEvaluation(source, "EvaluateTest", 7, "x1", _ == "\"x1x1\"")
+      assertEvaluation(source, "EvaluateTest", 7, "x1")(
+        _.exists(_ == "\"x1x1\"")
+      )
     }
 
     "should evaluate expression in package" - {
@@ -240,7 +259,9 @@ object ExpressionEvaluatorSpec extends TestSuite {
           |  }
           |}
           |""".stripMargin
-      assertEvaluation(source, "debug.EvaluateTest", 4, "1 + 2", _.toInt == 3)
+      assertEvaluation(source, "debug.EvaluateTest", 4, "1 + 2")(
+        _.exists(_.toInt == 3)
+      )
     }
 
     "should evaluate expression with Java util code" - {
@@ -255,9 +276,8 @@ object ExpressionEvaluatorSpec extends TestSuite {
         source,
         "EvaluateTest",
         3,
-        "new java.util.ArrayList[String]().toString",
-        _ == "\"[]\""
-      )
+        "new java.util.ArrayList[String]().toString"
+      )(_.exists(_ == "\"[]\""))
     }
 
     "should return null when expression is invalid" - {
@@ -268,7 +288,9 @@ object ExpressionEvaluatorSpec extends TestSuite {
           |  }
           |}
           |""".stripMargin
-      assertEvaluation(source, "EvaluateTest", 3, "1 ++ 2", _ == null)
+      assertEvaluation(source, "EvaluateTest", 3, "1 ++ 2")(
+        _.left.exists(_.format == "value ++ is not a member of Int")
+      )
     }
 
     "should evaluate expression inside of a lambda" - {
@@ -281,7 +303,7 @@ object ExpressionEvaluatorSpec extends TestSuite {
           |  }
           |}
           |""".stripMargin
-      assertEvaluation(source, "EvaluateTest", 4, "n", _.toInt == 1)
+      assertEvaluation(source, "EvaluateTest", 4, "n")(_.exists(_.toInt == 1))
     }
 
     "should evaluate expression a object's method call inside of a lambda" - {
@@ -296,7 +318,9 @@ object ExpressionEvaluatorSpec extends TestSuite {
           |  def m1(): Int = 9
           |}
           |""".stripMargin
-      assertEvaluation(source, "EvaluateTest", 4, "m1()", _.toInt == 9)
+      assertEvaluation(source, "EvaluateTest", 4, "m1()")(
+        _.exists(_.toInt == 9)
+      )
     }
 
     "should evaluate expression a class's method call inside of a lambda" - {
@@ -318,7 +342,9 @@ object ExpressionEvaluatorSpec extends TestSuite {
           |  }
           |}
           |""".stripMargin
-      assertEvaluation(source, "EvaluateTest", 4, "m2()", _.toInt == 10)
+      assertEvaluation(source, "EvaluateTest", 4, "m2()")(
+        _.exists(_.toInt == 10)
+      )
     }
   }
 
@@ -326,9 +352,8 @@ object ExpressionEvaluatorSpec extends TestSuite {
       source: String,
       mainClass: String,
       line: Int,
-      expression: String,
-      assertion: String => Boolean
-  ): Unit = {
+      expression: String
+  )(assertion: Either[Message, String] => Boolean): Unit = {
     val tempDir = IO.createTemporaryDirectory
     val srcDir = new File(tempDir, "src")
     IO.createDirectory(srcDir)

--- a/sbt/plugin/src/main/scala/ch/epfl/scala/debugadapter/sbtplugin/internal/InternalTasks.scala
+++ b/sbt/plugin/src/main/scala/ch/epfl/scala/debugadapter/sbtplugin/internal/InternalTasks.scala
@@ -29,9 +29,9 @@ private[sbtplugin] object InternalTasks {
 
   def tryResolveEvaluationClassLoader
       : Def.Initialize[Task[Option[URLClassLoader]]] = {
-    Def.optional(resolveEvaluationClassLoader) {
-      case None => TaskExtra.task(None)
-      case Some(t) => t.map(Some(_))
+    resolveEvaluationClassLoader.result.map {
+      case Inc(cause) => None
+      case Value(value) => Some(value)
     }
   }
 

--- a/sbt/plugin/src/sbt-test/debug-session/no-expression-compiler/build.sbt
+++ b/sbt/plugin/src/sbt-test/debug-session/no-expression-compiler/build.sbt
@@ -1,0 +1,43 @@
+import scala.concurrent.ExecutionContext
+import ch.epfl.scala.debugadapter.testing.TestDebugClient
+
+val checkDebugSession = inputKey[Unit]("Check the main class debug session")
+
+// there is no expression compiler for Scala 2.11
+scalaVersion := "2.11.12"
+
+// check that one can start a debug session even if the expression compiler
+// cannot be resolved
+checkDebugSession := {
+  implicit val ec: ExecutionContext = ExecutionContext.global
+
+  val uri = (Compile / startMainClassDebugSession).evaluated
+  val source = (Compile / sources).value.head.toPath
+
+  val client = TestDebugClient.connect(uri)
+  try {
+    client.initialize()
+    client.launch()
+
+    val breakpoints = client.setBreakpoints(source, Array(4))
+    assert(breakpoints.size == 1)
+    assert(breakpoints.forall(_.verified))
+
+    client.configurationDone()
+
+    val stopped = client.stopped()
+    assert(stopped.reason == "breakpoint")
+
+    val stackTrace = client.stackTrace(stopped.threadId)
+    val topFrame = stackTrace.stackFrames.head
+
+    val error = client.evaluate("1 + 1", topFrame.id).left
+    assert(error.exists(_.format == "an implementation is missing"))
+
+    client.continue(stopped.threadId)
+    client.exited()
+    client.terminated()
+  } finally {
+    client.close()
+  }
+}

--- a/sbt/plugin/src/sbt-test/debug-session/no-expression-compiler/project/plugins.sbt
+++ b/sbt/plugin/src/sbt-test/debug-session/no-expression-compiler/project/plugins.sbt
@@ -1,0 +1,12 @@
+val pluginVersion = sys.props
+  .get("plugin.version")
+  .getOrElse {
+    sys.error(
+      """|The system property 'plugin.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.
+         |""".stripMargin
+    )
+  }
+
+addSbtPlugin("ch.epfl.scala" % "sbt-debug-adapter" % pluginVersion)
+libraryDependencies += "ch.epfl.scala" %% "debug-adapter-test-client" % pluginVersion

--- a/sbt/plugin/src/sbt-test/debug-session/no-expression-compiler/project/project/plugins.sbt
+++ b/sbt/plugin/src/sbt-test/debug-session/no-expression-compiler/project/project/plugins.sbt
@@ -1,0 +1,2 @@
+// required for adopt@1.8
+addSbtPlugin("org.scala-debugger" % "sbt-jdi-tools" % "1.1.1")

--- a/sbt/plugin/src/sbt-test/debug-session/no-expression-compiler/src/main/scala/example/Hello.scala
+++ b/sbt/plugin/src/sbt-test/debug-session/no-expression-compiler/src/main/scala/example/Hello.scala
@@ -1,0 +1,5 @@
+package example
+
+object Hello extends App {
+  println("Hello")
+}

--- a/sbt/plugin/src/sbt-test/debug-session/no-expression-compiler/test
+++ b/sbt/plugin/src/sbt-test/debug-session/no-expression-compiler/test
@@ -1,0 +1,2 @@
+> 'checkDebugSession {"class":"example.Hello","arguments":[],"jvmOptions":[]}'
+> stopDebugSession

--- a/test-client/src/main/scala/ch/epfl/scala/debugadapter/testing/TestDebugClient.scala
+++ b/test-client/src/main/scala/ch/epfl/scala/debugadapter/testing/TestDebugClient.scala
@@ -143,14 +143,16 @@ class TestDebugClient(socket: Socket, debug: String => Unit)(implicit
       expression: String,
       frameId: Int,
       timeout: Duration = 6 seconds
-  ): String = {
+  ): Either[Message, String] = {
     val args = new EvaluateArguments()
     args.expression = expression
     args.frameId = frameId
     args.context = "repl"
     val request = createRequest(Command.EVALUATE, args)
     val response = sendRequest(request, timeout)
-    getBody[EvaluateResponseBody](response).result
+
+    Option(getBody[EvaluateResponseBody](response).result)
+      .toRight(getBody[ErrorResponseBody](response).error)
   }
 
   def disconnect(


### PR DESCRIPTION
When the expression compiler cannot be resolved, we should still be able to start a debug session, as before.