### PR TITLE
Prevent object reference from being collected

### DIFF
--- a/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/ExpressionCompilationFailed.scala
+++ b/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/ExpressionCompilationFailed.scala
@@ -1,0 +1,4 @@
+package ch.epfl.scala.debugadapter.internal.evaluator
+
+private[internal] class ExpressionCompilationFailed(message: String)
+    extends Exception(message)

--- a/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/ExpressionEvaluator.scala
+++ b/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/ExpressionEvaluator.scala
@@ -7,9 +7,11 @@ import com.microsoft.java.debug.core.adapter.{
 import com.sun.jdi._
 
 import java.nio.file.{Files, Path}
-import java.util.concurrent.CompletableFuture
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
+import scala.util.Try
+import scala.util.Success
+import scala.util.Failure
 
 private[internal] class ExpressionEvaluator(
     sourceLookUpProvider: ISourceLookUpProvider,
@@ -19,7 +21,7 @@ private[internal] class ExpressionEvaluator(
       expression: String,
       thread: ThreadReference,
       frame: StackFrame
-  )(debugContext: IDebugAdapterContext): CompletableFuture[Value] = {
+  ): Try[Value] = {
     val location = frame.location()
     val sourcePath = location.sourcePath()
     val breakpointLine = location.lineNumber()
@@ -28,67 +30,64 @@ private[internal] class ExpressionEvaluator(
     val uri = sourceLookUpProvider.getSourceFileURI(fqcn, sourcePath)
     val content = sourceLookUpProvider.getSourceContents(uri)
 
-    val expressionDir = Files.createTempDirectory("expr-eval")
-    val expressionId = java.util.UUID.randomUUID.toString.replace("-", "")
-    val expressionClassName: String = s"Expression$expressionId"
-    val valuesByNameIdentName: String = s"valuesByName$expressionId"
+    val randomId = java.util.UUID.randomUUID.toString.replace("-", "")
+    val expressionDir =
+      Files.createTempDirectory(s"scala-debug-adapter-$randomId")
+    val expressionClassName: String = s"Expression$randomId"
+    val valuesByNameIdentName: String = s"valuesByName$randomId"
 
     val expressionFqcn =
       (fqcn.split("\\.").dropRight(1) :+ expressionClassName).mkString(".")
-
-    try {
-      var error: Option[String] = None
-      val result = for {
-        classLoader <-
-          findClassLoader(thread)
-            .toRight("Failed finding class loader")
-        (names, values) = extractValuesAndNames(frame, classLoader)
-        classPath <- getClassPath(classLoader)
-          .toRight("Failed getting class path")
-        expressionClassPath = expressionDir.toUri.toString
-        compiledSuccessfully = expressionCompiler
-          .compile(
-            expressionDir,
-            expressionClassName,
-            valuesByNameIdentName,
-            classPath,
-            content,
-            breakpointLine,
-            expression,
-            names.map(_.value()).toSet,
-            errorMessage => error = Some(errorMessage),
-            5 seconds
-          )
-        _ <-
-          if (compiledSuccessfully) Right(())
-          else
-            Left("Compilation failed" + error.map(m => s": $m").getOrElse(""))
-        // if everything went smooth we can load our expression class
-        expressionInstance <-
-          createExpressionInstance(classLoader, expressionDir, expressionFqcn)
-            .toRight(s"Failed creating instance of ${expressionFqcn}")
-
-        namesArray <-
-          JdiArray("java.lang.String", names.size, classLoader)
-            .toRight("Failed creating array of names")
-        valuesArray <-
-          JdiArray("java.lang.Object", values.size, classLoader)
-            .toRight("Failed creating array of values") // add boxing
-        _ = namesArray.setValues(names)
-        _ = valuesArray.setValues(values)
-        val args = List(namesArray.reference, valuesArray.reference)
-        result <- expressionInstance
-          .invoke("evaluate", args)
-          .toRight("Failed invoking evaluate method")
-      } yield result
-
-      result match {
-        case Right(value) =>
-          CompletableFuture.completedFuture(value)
-        case Left(error) => throw new Exception(error)
+    var error: Option[String] = None
+    val classLoader = findClassLoader(thread)
+    val evaluatedValue = for {
+      // must be called before any invocation otherwise
+      // it throws an InvalidStackFrameException
+      (names, values) <- extractValuesAndNames(frame, classLoader)
+      classPath <- getClassPath(classLoader)
+      compiled = expressionCompiler
+        .compile(
+          expressionDir,
+          expressionClassName,
+          valuesByNameIdentName,
+          classPath,
+          content,
+          breakpointLine,
+          expression,
+          names.map(_.value()).toSet,
+          errorMessage => error = Some(errorMessage),
+          5 seconds
+        )
+      _ = {
+        if (!compiled)
+          throw new ExpressionCompilationFailed(error.getOrElse(""))
       }
-    } finally {
-      debugContext.getStackFrameManager.reloadStackFrames(thread)
+      // // if everything went smooth we can load our expression class
+      expressionInstance <-
+        createExpressionInstance(classLoader, expressionDir, expressionFqcn)
+
+      namesArray <-
+        JdiArray("java.lang.String", names.size, classLoader)
+      valuesArray <-
+        JdiArray("java.lang.Object", values.size, classLoader) // add boxing
+      _ = namesArray.setValues(names)
+      _ = valuesArray.setValues(values)
+      args = List(namesArray.reference, valuesArray.reference)
+      evaluatedValue <- evaluateExpression(expressionInstance, args)
+    } yield evaluatedValue
+    evaluatedValue.getResult
+  }
+
+  private def evaluateExpression(
+      expressionInstance: JdiObject,
+      args: List[ObjectReference]
+  ): Safe[Value] = {
+    Try(expressionInstance.invoke("evaluate", args)) match {
+      case Failure(cause: InvocationException) =>
+        // if invocation fails, return the exception as result
+        Safe(cause.exception)
+      case Failure(cause) => throw cause
+      case Success(value) => value
     }
   }
 
@@ -101,21 +100,20 @@ private[internal] class ExpressionEvaluator(
       classLoader: JdiClassLoader,
       expressionDir: Path,
       expressionFqcn: String
-  ): Option[JdiObject] = {
+  ): Safe[JdiObject] = {
     val expressionClassPath = expressionDir.toUri.toString
     for {
-      url <- classLoader
+      classPathValue <- classLoader.mirrorOf(expressionClassPath)
+      urlClass <- classLoader
         .loadClass("java.net.URL")
-        .flatMap(
-          _.newInstance(List(classLoader.vm.mirrorOf(expressionClassPath)))
-        )
+      url <- urlClass.newInstance(List(classPathValue))
       urls <- JdiArray("java.net.URL", 1, classLoader)
-      _ <- urls.setValue(0, url.reference)
+      _ = urls.setValue(0, url.reference)
       urlClassLoader <- classLoader
         .loadClass("java.net.URLClassLoader")
         .flatMap(_.newInstance(List(urls.reference)))
         .map(_.reference.asInstanceOf[ClassLoaderReference])
-        .flatMap(JdiClassLoader(_, classLoader.thread))
+        .map(JdiClassLoader(_, classLoader.thread))
       expressionClass <- urlClassLoader.loadClass(expressionFqcn)
       expressionInstance <- expressionClass.newInstance(List())
     } yield expressionInstance
@@ -131,58 +129,68 @@ private[internal] class ExpressionEvaluator(
   private def extractValuesAndNames(
       frame: StackFrame,
       classLoader: JdiClassLoader
-  ): (List[StringReference], List[Value]) = {
-    val thisObjectOpt = Option(frame.thisObject())
+  ): Safe[(List[StringReference], List[Value])] = {
+    val thisObjectOpt = Option(frame.thisObject) // this object can be null
+    def extractVariablesFromFrame()
+        : Safe[(List[StringReference], List[Value])] = {
 
-    def extractVariablesFromFrame() = {
       val variables: List[LocalVariable] =
         frame.visibleVariables().asScala.toList
-      val variableNames = variables.map(_.name()).map(classLoader.vm.mirrorOf)
-      val variableValues = variables
-        .map(frame.getValue)
-        .flatMap(value => boxIfNeeded(value, classLoader, classLoader.thread))
-      (variableNames, variableValues)
+      val variableNames =
+        variables.map(_.name).map(classLoader.mirrorOf).traverse
+      val variableValues =
+        variables
+          .map(frame.getValue)
+          .map(value => boxIfNeeded(value, classLoader, classLoader.thread))
+          .traverse
+      Safe.join(variableNames, variableValues)
     }
 
-    def extractFieldsFromThisObject() =
-      thisObjectOpt
-        .map { thisObject =>
-          val fields = thisObject.referenceType().fields().asScala.toList
-          val fieldNames = fields.map(_.name()).map(classLoader.vm.mirrorOf)
-          val fieldValues = fields
-            .map(field => thisObject.getValue(field))
-            .flatMap(value =>
-              boxIfNeeded(value, classLoader, classLoader.thread)
-            )
-          (fieldNames, fieldValues)
-        }
-        .getOrElse((Nil, Nil))
+    def extractFieldsFromThisObject(
+        thisObject: ObjectReference
+    ): Safe[(List[StringReference], List[Value])] = {
+      val fields = thisObject.referenceType.fields.asScala.toList
+      val fieldNames = fields.map(_.name).map(classLoader.mirrorOf).traverse
+      val fieldValues = fields
+        .map(field => thisObject.getValue(field))
+        .map(value => boxIfNeeded(value, classLoader, classLoader.thread))
+        .traverse
+      Safe.join(fieldNames, fieldValues)
+    }
 
-    val (variableNames, variableValues) = extractVariablesFromFrame()
-    val (fieldNames, fieldValues) = extractFieldsFromThisObject()
-    val thisObjectName =
-      thisObjectOpt.map(_ => classLoader.vm.mirrorOf("$this"))
-    val names = variableNames ++ fieldNames ++ thisObjectName.toList
-    val values = variableValues ++ fieldValues ++ thisObjectOpt.toList
-    (names, values)
+    for {
+      (variableNames, variableValues) <- extractVariablesFromFrame()
+      (fieldNames, fieldValues) <-
+        thisObjectOpt
+          .map(extractFieldsFromThisObject)
+          .getOrElse(Safe.lift((Nil, Nil)))
+      thisObjectName <- thisObjectOpt match {
+        case Some(thisObject) =>
+          classLoader.mirrorOf("$this").map(Some.apply)
+        case None => Safe.lift(None)
+      }
+    } yield {
+      val names = variableNames ++ fieldNames ++ thisObjectName
+      val values = variableValues ++ fieldValues ++ thisObjectOpt
+      (names, values)
+    }
   }
 
   private def findClassLoader(
       thread: ThreadReference
-  ): Option[JdiClassLoader] = {
-    thread.virtualMachine.allClasses.asScala
+  ): JdiClassLoader = {
+    val someClass = thread.virtualMachine.allClasses.asScala
       .find(_.classLoader() != null)
-      .flatMap(c => JdiClassLoader(c.classLoader, thread))
+      .head
+    JdiClassLoader(someClass.classLoader, thread)
   }
 
-  private def getClassPath(classLoader: JdiClassLoader): Option[String] = {
+  private def getClassPath(classLoader: JdiClassLoader): Safe[String] = {
     for {
       systemClass <- classLoader.loadClass("java.lang.System")
+      propertyValue <- classLoader.mirrorOf("java.class.path")
       classPath <- systemClass
-        .invokeStatic(
-          "getProperty",
-          List(classLoader.vm.mirrorOf("java.class.path"))
-        )
+        .invokeStatic("getProperty", List(propertyValue))
         .map(_.toString)
         .map(_.drop(1).dropRight(1)) // remove quotation marks
     } yield classPath
@@ -192,7 +200,7 @@ private[internal] class ExpressionEvaluator(
       value: Value,
       classLoader: JdiClassLoader,
       thread: ThreadReference
-  ) = value match {
+  ): Safe[Value] = value match {
     case value: BooleanValue =>
       JdiPrimitive.boxed(value.value(), classLoader, thread).map(_.reference)
     case value: CharValue =>
@@ -207,6 +215,6 @@ private[internal] class ExpressionEvaluator(
       JdiPrimitive.boxed(value.value(), classLoader, thread).map(_.reference)
     case value: ShortValue =>
       JdiPrimitive.boxed(value.value(), classLoader, thread).map(_.reference)
-    case value => Some(value)
+    case value => Safe(value)
   }
 }

--- a/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/JdiClassObject.scala
+++ b/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/JdiClassObject.scala
@@ -5,37 +5,40 @@ import com.sun.jdi._
 import scala.util.Try
 
 class JdiClassObject(
-    override val reference: ClassObjectReference,
+    reference: ClassObjectReference,
     classLoader: JdiClassLoader,
     thread: ThreadReference
 ) extends JdiObject(reference, thread) {
-  private val vm = thread.virtualMachine()
 
-  def newInstance(args: List[Value]): Option[JdiObject] = {
-    val parameterTypes =
-      args.map(_.`type`().asInstanceOf[ReferenceType].classObject())
+  def newInstance(args: List[ObjectReference]): Safe[JdiObject] = {
+    val parameterTypes = args.map(_.referenceType.classObject())
     for {
       objects <- JdiArray("java.lang.Object", args.size, classLoader)
-      _ <- objects.setValues(args)
+      _ = objects.setValues(args)
       constructor <- invoke("getConstructor", parameterTypes)
         .map(_.asInstanceOf[ObjectReference])
         .map(new JdiObject(_, thread))
-      instance <- constructor.invoke("newInstance", List(objects.reference))
-      jdiObject <- Try(instance.asInstanceOf[ObjectReference]).toOption
+      jdiObject <- constructor
+        .invoke("newInstance", List(objects.reference))
+        .map(_.asInstanceOf[ObjectReference])
         .map(new JdiObject(_, thread))
     } yield jdiObject
   }
 
-  def invokeStatic(methodName: String, args: List[Value]): Option[Value] = for {
-    parameterTypes <- Some(
-      args.map(_.`type`().asInstanceOf[ReferenceType].classObject())
-    )
-    method <- invoke(
-      "getMethod",
-      List(vm.mirrorOf(methodName)) ++ parameterTypes
-    )
-      .map(_.asInstanceOf[ObjectReference])
-      .map(new JdiObject(_, thread))
-    result <- method.invoke("invoke", List(null) ++ args)
-  } yield result
+  def invokeStatic(
+      methodName: String,
+      args: List[ObjectReference]
+  ): Safe[Value] = {
+    val parameterTypes = args.map(_.referenceType.classObject())
+    for {
+      methodNameValue <- classLoader.mirrorOf(methodName)
+      method <- invoke(
+        "getMethod",
+        methodNameValue :: parameterTypes
+      )
+        .map(_.asInstanceOf[ObjectReference])
+        .map(new JdiObject(_, thread))
+      result <- method.invoke("invoke", List(null) ++ args)
+    } yield result
+  }
 }

--- a/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/JdiObject.scala
+++ b/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/JdiObject.scala
@@ -6,17 +6,17 @@ private[internal] class JdiObject(
     val reference: ObjectReference,
     thread: ThreadReference
 ) {
-  def invoke(methodName: String, args: List[Value]): Option[Value] = for {
-    method <- method(methodName, reference.referenceType())
-    result <- invokeMethod(reference, method, args, thread)
-  } yield result
+  def invoke(methodName: String, args: List[Value]): Safe[Value] = {
+    val m = method(methodName, reference.referenceType)
+    invokeMethod(reference, m, args, thread)
+  }
 
   def invoke(
       methodName: String,
       signature: String,
       args: List[Value]
-  ): Option[Value] = for {
-    method <- method(methodName, signature, reference.referenceType())
-    result <- invokeMethod(reference, method, args, thread)
-  } yield result
+  ): Safe[Value] = {
+    val m = method(methodName, signature, reference.referenceType())
+    invokeMethod(reference, m, args, thread)
+  }
 }

--- a/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/JdiPrimitive.scala
+++ b/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/JdiPrimitive.scala
@@ -7,10 +7,9 @@ object JdiPrimitive {
       value: AnyVal,
       classLoader: JdiClassLoader,
       thread: ThreadReference
-  ): Option[JdiObject] = {
-    val vm = thread.virtualMachine()
-    val jdiValue = vm.mirrorOf(value.toString)
+  ): Safe[JdiObject] = {
     for {
+      jdiValue <- classLoader.mirrorOf(value.toString)
       clazz <- value match {
         case _: Boolean => classLoader.loadClass("java.lang.Boolean")
         case _: Byte => classLoader.loadClass("java.lang.Byte")

--- a/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/Safe.scala
+++ b/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/Safe.scala
@@ -1,0 +1,70 @@
+package ch.epfl.scala.debugadapter.internal.evaluator
+
+import com.sun.jdi._
+import scala.util.Try
+import scala.util.Failure
+import scala.util.Success
+
+/**
+ * Objects created on the remote JVM can be garbage-collected at any time.
+ * https://stackoverflow.com/questions/25793688/life-span-of-jdi-mirrors-of-objects-living-in-a-remote-jvm
+ *
+ * This can be prevented by wrapping every object reference into a [[Safe]]
+ * instance. It calls `disableCollection` at construction and `enableCollection`
+ * when the final result is retrieved.
+ *
+ * You can get the result out of a [[Safe]] instance by calling `getResult`.
+ * Then the object references are not protected anymore and can be
+ * normally garbage collected.
+ */
+class Safe[A] private (
+    private val result: Try[A],
+    private val dispose: () => Unit
+) {
+  def map[B](f: A => B): Safe[B] = new Safe(result.map(f), dispose)
+
+  def flatMap[B](f: A => Safe[B]): Safe[B] = {
+    result match {
+      case Failure(exception) => new Safe(Failure(exception), dispose)
+      case Success(a) =>
+        val b = f(a)
+        new Safe(b.result, () => { dispose(); b.dispose() })
+    }
+  }
+
+  def getResult: Try[A] = {
+    dispose()
+    result
+  }
+
+  def withFilter(p: A => Boolean): Safe[A] = {
+    new Safe(result.withFilter(p).map(identity), dispose)
+  }
+}
+
+object Safe {
+  def apply[A <: Value](f: => A): Safe[A] = {
+    val result = Try(f)
+    result match {
+      case Success(value) =>
+        value match {
+          case obj: ObjectReference =>
+            new Safe(
+              Try(obj.disableCollection()).map(_ => value),
+              () => Try(obj.enableCollection())
+            )
+          case _ => lift(value)
+        }
+      case Failure(exception) =>
+        new Safe(Failure(exception), () => ())
+    }
+  }
+
+  def lift[A](a: A): Safe[A] = {
+    new Safe(Success(a), () => ())
+  }
+
+  def join[A, B](safeA: Safe[A], safeB: Safe[B]): Safe[(A, B)] = {
+    safeA.flatMap(a => safeB.map(b => (a, b)))
+  }
+}

--- a/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/package.scala
+++ b/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/package.scala
@@ -3,46 +3,41 @@ package ch.epfl.scala.debugadapter.internal
 import com.sun.jdi._
 
 import scala.collection.JavaConverters._
-import scala.util.{Failure, Success, Try}
 
 package object evaluator {
-  private[evaluator] def method(name: String, referenceType: ReferenceType) =
-    Try(referenceType.methodsByName(name).asScala.headOption).toOption.flatten
+  private[evaluator] def method(
+      name: String,
+      referenceType: ReferenceType
+  ): Method =
+    referenceType.methodsByName(name).asScala.head
 
   private[evaluator] def method(
       name: String,
       signature: String,
       referenceType: ReferenceType
-  ) =
-    Try(
-      referenceType.methodsByName(name, signature).asScala.headOption
-    ).toOption.flatten
+  ): Method =
+    referenceType.methodsByName(name, signature).asScala.head
 
   private[evaluator] def invokeMethod(
       objRef: ObjectReference,
       method: Method,
       args: List[Value],
       thread: ThreadReference
-  ) =
-    Try(
+  ): Safe[Value] =
+    Safe(
       objRef.invokeMethod(
         thread,
         method,
         args.asJava,
         ObjectReference.INVOKE_SINGLE_THREADED
       )
-    ) match {
-      case Failure(error: InvocationException) =>
-        println(s"InvocationException: ${error.exception()}")
-        None
-      case Failure(exception) =>
-        println(s"${exception.getClass.getSimpleName}: ${exception.getMessage}")
-        None
-      case Success(result) => Some(result)
-    }
+    )
 
-  private[evaluator] def classLoader(
-      objRef: ObjectReference
-  ): Option[ClassLoaderReference] =
-    Try(objRef.referenceType().classLoader()).toOption
+  implicit class SafeList[A](seq: List[Safe[A]]) {
+    def traverse: Safe[List[A]] = {
+      seq.foldRight(Safe.lift(List.empty[A])) { (safeHead, safeTail) =>
+        safeTail.flatMap(tail => safeHead.map(head => head :: tail))
+      }
+    }
+  }
 }

--- a/core/src/test/scala/ch/epfl/scala/debugadapter/ExpressionEvaluatorSpec.scala
+++ b/core/src/test/scala/ch/epfl/scala/debugadapter/ExpressionEvaluatorSpec.scala
@@ -288,11 +288,11 @@ object ExpressionEvaluatorSpec extends TestSuite {
           |  }
           |}
           |""".stripMargin
-      assertEvaluation(source, "EvaluateTest", 3, "1 ++ 2")(
-        _.left.exists(
-          _.format == "Compilation failed: value ++ is not a member of Int"
-        )
-      )
+      assertEvaluation(source, "EvaluateTest", 3, "1 ++ 2") { result =>
+        result.left.exists { msg =>
+          msg.format.contains("value ++ is not a member of Int")
+        }
+      }
     }
 
     "should evaluate expression inside of a lambda" - {
@@ -362,7 +362,7 @@ object ExpressionEvaluatorSpec extends TestSuite {
           |}
           |""".stripMargin
       assertEvaluation(source, "test.EvaluateTest", 7, "\"Hello\"") { res =>
-        res.left.exists(_.format.startsWith("Compilation timed out"))
+        res.left.exists(_.format.contains("Compilation timed out"))
       }
     }
   }

--- a/sbt/plugin/src/sbt-test/debug-session/no-expression-compiler/build.sbt
+++ b/sbt/plugin/src/sbt-test/debug-session/no-expression-compiler/build.sbt
@@ -32,7 +32,11 @@ checkDebugSession := {
     val topFrame = stackTrace.stackFrames.head
 
     val error = client.evaluate("1 + 1", topFrame.id).left
-    assert(error.exists(_.format == "an implementation is missing"))
+    assert(
+      error.exists(
+        _.format.contains("Missing evaluator for this debug session")
+      )
+    )
 
     client.continue(stopped.threadId)
     client.exited()


### PR DESCRIPTION
Objects created on the remote JVM can be garbage-collected at any time.
So during expression evaluation, we need to protect those by calling `disableCollection`.
We also need to call `enableCollection` after the expression evaluation succeeded or failed.

For reference, see https://stackoverflow.com/questions/25793688/life-span-of-jdi-mirrors-of-objects-living-in-a-remote-jvm

To do so I introduce a `Safe[T]` class which encapsulates the result of a computation on remote objects.
All remote are protected until one calls `safe.getResult`, which enables the garbage collection once again.