### PR TITLE
Fix expression evaluation

### DIFF
--- a/core/src/test/scala/ch/epfl/scala/debugadapter/DebugServerSpec.scala
+++ b/core/src/test/scala/ch/epfl/scala/debugadapter/DebugServerSpec.scala
@@ -20,7 +20,8 @@ object DebugServerSpec extends TestSuite {
   private val connectionFailedMessages = Array(
     "(Connection refused)",
     "(Connection Failed)",
-    "(connect failed)"
+    "(connect failed)",
+    "Connection reset by peer"
   )
 
   def tests: Tests = Tests {

--- a/core/src/test/scala/ch/epfl/scala/debugadapter/ExpressionEvaluatorSpec.scala
+++ b/core/src/test/scala/ch/epfl/scala/debugadapter/ExpressionEvaluatorSpec.scala
@@ -349,21 +349,35 @@ object ExpressionEvaluatorSpec extends TestSuite {
       )
     }
 
-    "should not loop indefinitely" - {
+    "should evaluate expression with breakpoint on an assignment" - {
       val source =
-        """package test
-          |
-          |object EvaluateTest extends App {
-          |  m()
-          |
-          |  def m(): Unit = {
-          |    val a = List(1, 2)
+        """object EvaluateTest {
+          |  def main(args: Array[String]): Unit = {
+          |    val a = 1
+          |    println("Hello, World!")
           |  }
           |}
           |""".stripMargin
-      assertEvaluation(source, "test.EvaluateTest", 7, "\"Hello\"") { res =>
-        res.left.exists(_.format.contains("Compilation timed out"))
-      }
+      assertEvaluation(source, "EvaluateTest", 3, "1 + 2")(
+        _.exists(_.toInt == 3)
+      )
+    }
+
+    "should evaluate expression with breakpoint on method definition" - {
+      val source =
+        """class Foo {
+          |  def bar(): String = "foobar"
+          |}
+          |
+          |object EvaluateTest {
+          |  def main(args: Array[String]): Unit = {
+          |    new Foo().bar()
+          |  }
+          |}
+          |""".stripMargin
+      assertEvaluation(source, "EvaluateTest", 2, "1 + 2")(
+        _.exists(_.toInt == 3)
+      )
     }
   }
 

--- a/core/src/test/scala/ch/epfl/scala/debugadapter/ExpressionEvaluatorSuite.scala
+++ b/core/src/test/scala/ch/epfl/scala/debugadapter/ExpressionEvaluatorSuite.scala
@@ -10,7 +10,13 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import com.microsoft.java.debug.core.protocol.Types.Message
 
-object ExpressionEvaluatorSpec extends TestSuite {
+object Scala212EvaluatorSpec
+    extends ExpressionEvaluatorSuite(ScalaVersion.`2.12`)
+object Scala213EvaluatorSpec
+    extends ExpressionEvaluatorSuite(ScalaVersion.`2.13`)
+
+abstract class ExpressionEvaluatorSuite(scalaVersion: ScalaVersion)
+    extends TestSuite {
   // the server needs only one thread for delayed responses of the launch and configurationDone requests
   private val executorService = Executors.newFixedThreadPool(1)
   private implicit val ec =
@@ -398,7 +404,8 @@ object ExpressionEvaluatorSpec extends TestSuite {
       "EvaluateTest.scala",
       source,
       mainClass,
-      outDir
+      outDir,
+      scalaVersion
     )
     val server = DebugServer(runner, NoopLogger)
     val client = TestDebugClient.connect(server.uri, 20.seconds)

--- a/core/src/test/scala/ch/epfl/scala/debugadapter/MainDebuggeeRunner.scala
+++ b/core/src/test/scala/ch/epfl/scala/debugadapter/MainDebuggeeRunner.scala
@@ -96,11 +96,12 @@ object MainDebuggeeRunner {
       filename: String,
       source: String,
       mainClass: String,
-      outDir: File
+      outDir: File,
+      scalaVersion: ScalaVersion
   ): MainDebuggeeRunner = {
     val path = new File(srcDir, filename).toPath
     Files.write(path, source.getBytes())
-    compileScala(path, mainClass, outDir, ScalaVersion.`2.12`)
+    compileScala(path, mainClass, outDir, scalaVersion)
   }
 
   private def getResource(name: String): Path =

--- a/core/src/test/scala/ch/epfl/scala/debugadapter/ScalaVersions.scala
+++ b/core/src/test/scala/ch/epfl/scala/debugadapter/ScalaVersions.scala
@@ -27,7 +27,7 @@ final case class Scala3(version: String) extends ScalaVersion {
 }
 
 object ScalaVersion {
-  val `2.12` = Scala2("2.12.14")
+  val `2.12` = Scala2("2.12.15")
   val `2.13` = Scala2("2.13.6")
   val `3` = Scala3("3.0.0")
 }

--- a/test-client/src/main/scala/ch/epfl/scala/debugadapter/testing/TestDebugClient.scala
+++ b/test-client/src/main/scala/ch/epfl/scala/debugadapter/testing/TestDebugClient.scala
@@ -31,7 +31,7 @@ class TestDebugClient(socket: Socket, debug: String => Unit)(implicit
     socket.close()
   }
 
-  def initialize(timeout: Duration = 4 seconds): Messages.Response = {
+  def initialize(timeout: Duration = 8 seconds): Messages.Response = {
     val args = new InitializeArguments()
     args.linesStartAt1 = true
     args.columnsStartAt1 = true


### PR DESCRIPTION
- fix expression evaluation on breakpoint with a definition or an assignment,
- revert to the non-interactive compiler to avoid `macro has not been expanded` error.