### PR TITLE
Fix expression evaluation when at definition

### DIFF
--- a/core/src/test/scala/ch/epfl/scala/debugadapter/ExpressionEvaluatorSuite.scala
+++ b/core/src/test/scala/ch/epfl/scala/debugadapter/ExpressionEvaluatorSuite.scala
@@ -359,12 +359,26 @@ abstract class ExpressionEvaluatorSuite(scalaVersion: ScalaVersion)
       val source =
         """object EvaluateTest {
           |  def main(args: Array[String]): Unit = {
-          |    val a = 1
-          |    println("Hello, World!")
+          |    val a = "Hello, World!"
+          |    println(a)
           |  }
           |}
           |""".stripMargin
       assertEvaluation(source, "EvaluateTest", 3, "1 + 2")(
+        _.exists(_.toInt == 3)
+      )
+    }
+
+    "should evaluate expression with breakpoint on last statement" - {
+      val source =
+        """object EvaluateTest {
+          |  def main(args: Array[String]): Unit = {
+          |    val a = "Hello, World!"
+          |    println(a)
+          |  }
+          |}
+          |""".stripMargin
+      assertEvaluation(source, "EvaluateTest", 4, "1 + 2")(
         _.exists(_.toInt == 3)
       )
     }

--- a/core/src/test/scala/ch/epfl/scala/debugadapter/ExpressionEvaluatorSuite.scala
+++ b/core/src/test/scala/ch/epfl/scala/debugadapter/ExpressionEvaluatorSuite.scala
@@ -369,20 +369,6 @@ abstract class ExpressionEvaluatorSuite(scalaVersion: ScalaVersion)
       )
     }
 
-    "should evaluate expression with breakpoint on last statement" - {
-      val source =
-        """object EvaluateTest {
-          |  def main(args: Array[String]): Unit = {
-          |    val a = "Hello, World!"
-          |    println(a)
-          |  }
-          |}
-          |""".stripMargin
-      assertEvaluation(source, "EvaluateTest", 4, "1 + 2")(
-        _.exists(_.toInt == 3)
-      )
-    }
-
     "should evaluate expression with breakpoint on method definition" - {
       val source =
         """class Foo {


### PR DESCRIPTION
Previously, we would create a new block at the breakpoint line, which could break the evaluated code when definition was present. Now, we instead input the expression into block stats, which no longer modifes the existing values.

Fixes https://github.com/scalacenter/scala-debug-adapter/issues/103