### PR TITLE
Always wrap single definition in block

### DIFF
--- a/core/src/test/scala/ch/epfl/scala/debugadapter/ExpressionEvaluatorSuite.scala
+++ b/core/src/test/scala/ch/epfl/scala/debugadapter/ExpressionEvaluatorSuite.scala
@@ -385,6 +385,19 @@ abstract class ExpressionEvaluatorSuite(scalaVersion: ScalaVersion)
         _.exists(_.toInt == 3)
       )
     }
+
+    "should evaluate expression definition" - {
+      val source =
+        """|object EvaluateTest {
+           |  def main(args: Array[String]): Unit = {
+           |    println("Hello, World!")
+           |  }
+           |}
+           |""".stripMargin
+      assertEvaluation(source, "EvaluateTest", 3, "val x = 123")(
+        _.exists(_ == "<void value>")
+      )
+    }
   }
 
   private def assertEvaluation(

--- a/expression-compiler/src/main/scala-2/scala/tools/nsc/EvalGlobal.scala
+++ b/expression-compiler/src/main/scala-2/scala/tools/nsc/EvalGlobal.scala
@@ -78,12 +78,17 @@ private[nsc] class EvalGlobal(
         val parsedWrappedExpression =
           parse("<wrapped-expression>", wrappedExpressionSource)
             .asInstanceOf[PackageDef]
-        parsedWrappedExpression.stats.head
+        val parsed = parsedWrappedExpression.stats.head
           .asInstanceOf[ModuleDef]
           .impl
           .body
           .last
           .setPos(NoPosition)
+        parsed match {
+          case df: ValOrDefDef =>
+            Block(df, Literal(Constant()))
+          case expr => expr
+        }
       }
 
       private def parseExpressionClass(source: String): Tree = {


### PR DESCRIPTION
Previously, expression evaluator would fail if expression was a definition. Now, it will be wrapped in a block.