### PR TITLE
Fix issues when breakpoint contains lambda parameter

### DIFF
--- a/core/src/test/scala/ch/epfl/scala/debugadapter/ExpressionEvaluatorSuite.scala
+++ b/core/src/test/scala/ch/epfl/scala/debugadapter/ExpressionEvaluatorSuite.scala
@@ -573,6 +573,22 @@ abstract class ExpressionEvaluatorSuite(scalaVersion: ScalaVersion)
         _.exists(_ == "\"Hello World!\"")
       )
     }
+
+    "should evaluate at lambda start" - {
+      val source =
+        """|object EvaluateTest{
+           |  def main(args: Array[String]): Unit = {
+           |    val list = List(1, 2, 3)
+           |    list.foreach { x => 
+           |      println(x)
+           |    }
+           |  }
+           |}
+           |""".stripMargin
+      assertEvaluation(source, "EvaluateTest", 4, "1 + 1")(
+        _.exists(_.toInt == 2)
+      )
+    }
   }
 
   case class ExpressionEvaluation(


### PR DESCRIPTION
Fixes https://github.com/scalacenter/scala-debug-adapter/issues/132

This also needs some changes when it comes to default arguments, since previously extracted expression would be assigned multiple times and the second time was correct.