### PR TITLE
Fix #148: Pass classpath to ExpressionEvaluator

### DIFF
--- a/core/src/main/scala/ch/epfl/scala/debugadapter/internal/EvaluationProvider.scala
+++ b/core/src/main/scala/ch/epfl/scala/debugadapter/internal/EvaluationProvider.scala
@@ -24,7 +24,13 @@ private[internal] object EvaluationProvider {
   ): IEvaluationProvider = {
     val evaluator = runner.evaluationClassLoader
       .flatMap(ExpressionCompiler(_))
-      .map(new ExpressionEvaluator(sourceLookUpProvider, _))
+      .map(
+        new ExpressionEvaluator(
+          runner.classPathEntries,
+          sourceLookUpProvider,
+          _
+        )
+      )
     new EvaluationProvider(evaluator)
   }
 }


### PR DESCRIPTION
When the classpath is too big and exceeds the maximum size of a command line, Bloop creates a `/tmp/jvm-forker-manifest2949990240171503800.jar` file which contains the classpath in a manifest file. But the Scala compiler does not support this and fails with:  `object scala in compiler mirror not found.`.

To fix this we pass the full classpath explicitly to the expression evaluator.

Tested locally:
```scala
package example

object Main {
  def main(args: Array[String]): Unit = {
    println(s"Classpath -> ${System.getProperty("java.class.path")}")
=>  println("Hello, World")
  }
}
```
Classpath is `/tmp/jvm-forker-manifest5241138918947448719.jar` and expression evaluation does work.


