### PR TITLE
Use runner's classpath instead of classpath entries

### DIFF
--- a/core/src/main/scala/ch/epfl/scala/debugadapter/internal/EvaluationProvider.scala
+++ b/core/src/main/scala/ch/epfl/scala/debugadapter/internal/EvaluationProvider.scala
@@ -26,7 +26,7 @@ private[internal] object EvaluationProvider {
       .flatMap(ExpressionCompiler(_))
       .map(
         new ExpressionEvaluator(
-          runner.classPathEntries,
+          runner.classPath,
           sourceLookUpProvider,
           _
         )

--- a/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/ExpressionEvaluator.scala
+++ b/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/ExpressionEvaluator.scala
@@ -12,12 +12,12 @@ import scala.concurrent.duration._
 import scala.util.Try
 
 private[internal] class ExpressionEvaluator(
-    classPathEntries: Seq[ClassPathEntry],
+    classPath: Seq[Path],
     sourceLookUpProvider: ISourceLookUpProvider,
     expressionCompiler: ExpressionCompiler
 ) {
-  private val classPath =
-    classPathEntries.map(_.absolutePath).mkString(File.pathSeparator)
+  private val classPathString =
+    classPath.mkString(File.pathSeparator)
 
   def evaluate(
       expression: String,
@@ -53,7 +53,7 @@ private[internal] class ExpressionEvaluator(
           expressionClassName,
           valuesByNameIdentName,
           callPrivateMethodName,
-          classPath,
+          classPathString,
           content,
           breakpointLine,
           expression,


### PR DESCRIPTION
The default is already to use classpath entries so we should use the actual runner classpath.