### PR TITLE
Don't allow expression evaluation in Java files

### DIFF
--- a/core/src/main/scala/ch/epfl/scala/debugadapter/internal/EvaluationProvider.scala
+++ b/core/src/main/scala/ch/epfl/scala/debugadapter/internal/EvaluationProvider.scala
@@ -57,11 +57,16 @@ private[internal] class EvaluationProvider(
       depth: Int
   ): CompletableFuture[Value] = {
     val frame = thread.frames().get(depth)
+    val isJava = frame.location().sourcePath().endsWith(".java")
     val future = new CompletableFuture[Value]()
     evaluator match {
       case None =>
         future.completeExceptionally(
           new Exception("Missing evaluator for this debug session")
+        )
+      case _ if isJava =>
+        future.completeExceptionally(
+          new Exception("Cannot evaluate Java sources")
         )
       case Some(evaluator) =>
         evaluationBlock {


### PR DESCRIPTION
Related to https://github.com/scalameta/metals/issues/2011

I thought it might be possible to use Java expression evaluator, but turns out you need OSGI for it.