### PR TITLE
Run even if some source jars are corrupted

### DIFF
--- a/core/src/main/scala/ch/epfl/scala/debugadapter/ClassSystem.scala
+++ b/core/src/main/scala/ch/epfl/scala/debugadapter/ClassSystem.scala
@@ -8,24 +8,26 @@ import java.nio.file.Files
 import java.nio.file.Path
 
 sealed trait ClassSystem {
-  def within[T](f: (FileSystem, Path) => T): T
+  def within[T](f: (FileSystem, Path) => T): Option[T]
 }
 
 final case class ClassJar(absolutePath: Path) extends ClassSystem {
-  def within[T](f: (FileSystem, Path) => T): T =
+  def within[T](f: (FileSystem, Path) => T): Option[T] =
     IO.withinJarFile(absolutePath)(fs => f(fs, fs.getPath("/")))
 }
 
 final case class ClassDirectory(absolutePath: Path) extends ClassSystem {
-  def within[T](f: (FileSystem, Path) => T): T =
-    f(FileSystems.getDefault, absolutePath)
+  def within[T](f: (FileSystem, Path) => T): Option[T] =
+    Some(f(FileSystems.getDefault, absolutePath))
 }
 
 final case class JavaRuntimeSystem(classLoader: ClassLoader, javaHome: Path)
     extends ClassSystem {
-  def within[T](f: (FileSystem, Path) => T): T = {
-    IO.withinJavaRuntimeFileSystem(classLoader, javaHome)(fs =>
-      f(fs, fs.getPath("/modules"))
+  def within[T](f: (FileSystem, Path) => T): Option[T] = {
+    Some(
+      IO.withinJavaRuntimeFileSystem(classLoader, javaHome)(fs =>
+        f(fs, fs.getPath("/modules"))
+      )
     )
   }
 }

--- a/core/src/test/scala/ch/epfl/scala/debugadapter/internal/ClassEntryLookUpSpec.scala
+++ b/core/src/test/scala/ch/epfl/scala/debugadapter/internal/ClassEntryLookUpSpec.scala
@@ -75,5 +75,16 @@ object ClassEntryLookUpSpec extends TestSuite {
       val contentSize = sourceFileContent.fold(0)(_.size)
       assert(contentSize == 8717)
     }
+
+    "should work in case of broken dependency jar" - {
+      val classPathEntry =
+        Coursier.fetchOnly("org.webjars", "swagger-ui", "4.2.1")
+      val lookUp = ClassEntryLookUp(classPathEntry)
+      val sourceJar = classPathEntry.sourceEntries.collectFirst {
+        case SourceJar(jar) => jar
+      }
+      assert(sourceJar.isDefined)
+      assert(lookUp.sources.isEmpty)
+    }
   }
 }


### PR DESCRIPTION
It seems if we are unable to read a source jar, not debug session will be started currently. This can happen if we get a broken source jar such as the one in https://github.com/scalameta/metals/issues/3584

Tested it manually and it seems to help.