### PR TITLE
Use run / baseDirectory for debugger

### DIFF
--- a/sbt/plugin/src/main/scala/ch/epfl/scala/debugadapter/sbtplugin/DebugAdapterPlugin.scala
+++ b/sbt/plugin/src/main/scala/ch/epfl/scala/debugadapter/sbtplugin/DebugAdapterPlugin.scala
@@ -196,7 +196,7 @@ object DebugAdapterPlugin extends sbt.AutoPlugin {
       val target = Keys.bspTargetIdentifier.value
       val scalaVersion = Keys.scalaVersion.value
       val javaHome = Keys.javaHome.value
-      val workingDirectory = Keys.baseDirectory.value
+      val workingDirectory = (Keys.run / Keys.baseDirectory).value
       val classPathEntries = InternalTasks.classPathEntries.value
       val javaRuntime = InternalTasks.javaRuntime.value
       val envVars = Keys.envVars.value


### PR DESCRIPTION
Fixes #262 

Changed to `run / baseDirectory`, but this could be narrowed down even to `Compile / run / baseDirectory` if being the most strict.

The builds, where the most generic `baseDirectory` was changed should continue to work w/o breakage.

Can retarget this to `2.2.x` if this makes any sense.