### PR TITLE
Use IStepFilterProvider to skip breakpoints

### DIFF
--- a/core/src/main/scala/ch/epfl/scala/debugadapter/internal/SourceLookUpProvider.scala
+++ b/core/src/main/scala/ch/epfl/scala/debugadapter/internal/SourceLookUpProvider.scala
@@ -45,6 +45,9 @@ private[debugadapter] final class SourceLookUpProvider(
     }
   }
 
+  def getClassFile(fqcn: String): Option[ClassFile] =
+    fqcnToClassPathEntry.get(fqcn).flatMap(_.getClassFile(fqcn))
+
   def getClassEntry(fqcn: String): Option[ClassEntry] =
     fqcnToClassPathEntry.get(fqcn).map(_.entry)
 

--- a/core/src/main/scala/ch/epfl/scala/debugadapter/internal/StepFilterProvider.scala
+++ b/core/src/main/scala/ch/epfl/scala/debugadapter/internal/StepFilterProvider.scala
@@ -16,9 +16,9 @@ class StepFilterProvider(
     testMode: Boolean
 ) extends JavaStepFilterProvider() {
 
-  override def shouldStepInto(method: Method, filters: StepFilters): Boolean = {
+  override def shouldSkipOver(method: Method, filters: StepFilters): Boolean = {
     try {
-      val shouldSkip = super.shouldStepInto(method, filters) || stepFilters.exists(_.shouldStepInto(method))
+      val shouldSkip = super.shouldSkipOver(method, filters) || stepFilters.exists(_.shouldSkipOver(method))
       if (shouldSkip) logger.debug(s"Skipping $method (step into)")
       shouldSkip
     } catch {
@@ -29,11 +29,11 @@ class StepFilterProvider(
     }
   }
 
-  override def shouldStepOut(upperLocation: Location, method: Method): Boolean = {
+  override def shouldSkipOut(upperLocation: Location, method: Method): Boolean = {
     try {
       val shouldSkip =
-        super.shouldStepOut(upperLocation, method) ||
-          stepFilters.exists(_.shouldStepOut(upperLocation, method))
+        super.shouldSkipOut(upperLocation, method) ||
+          stepFilters.exists(_.shouldSkipOut(upperLocation, method))
       if (shouldSkip) logger.debug(s"Skipping $method (step out)")
       shouldSkip
     } catch {

--- a/core/src/main/scala/ch/epfl/scala/debugadapter/internal/scalasig/Decompiler.scala
+++ b/core/src/main/scala/ch/epfl/scala/debugadapter/internal/scalasig/Decompiler.scala
@@ -40,7 +40,6 @@ private[internal] object Decompiler {
 
     val scalaAnnotations = scala.collection.mutable.Buffer[String]()
 
-    val emptyVisitor = new AnnotationVisitor(Opcodes.ASM9) {}
     val scalaVisitor = new AnnotationVisitor(Opcodes.ASM9) {
       override def visitArray(name: String): AnnotationVisitor = {
         if (name == "bytes") {
@@ -49,9 +48,7 @@ private[internal] object Decompiler {
               scalaAnnotations += value.asInstanceOf[String]
             }
           }
-        } else {
-          emptyVisitor
-        }
+        } else super.visitArray(name)
       }
 
       override def visit(name: String, value: Any): Unit = {
@@ -70,7 +67,7 @@ private[internal] object Decompiler {
         descriptor match {
           case SCALA_SIG_ANNOTATION | SCALA_LONG_SIG_ANNOTATION =>
             scalaVisitor
-          case _ => emptyVisitor
+          case _ => super.visitAnnotation(descriptor, visible)
         }
       }
     }

--- a/core/src/main/scala/ch/epfl/scala/debugadapter/internal/stepfilter/ClassLoadingFilter.scala
+++ b/core/src/main/scala/ch/epfl/scala/debugadapter/internal/stepfilter/ClassLoadingFilter.scala
@@ -4,7 +4,7 @@ import com.sun.jdi.{Location, Method}
 import ch.epfl.scala.debugadapter.internal.ByteCodes
 
 object ClassLoadingStepFilter extends StepFilter {
-  override def shouldStepOut(upperLocation: Location, method: Method): Boolean = {
+  override def shouldSkipOut(upperLocation: Location, method: Method): Boolean = {
     val previousByteCode = upperLocation.method.bytecodes.apply(upperLocation.codeIndex.toInt)
     previousByteCode == ByteCodes.NEW && method.name != "<init>"
   }

--- a/core/src/main/scala/ch/epfl/scala/debugadapter/internal/stepfilter/RuntimeStepFilter.scala
+++ b/core/src/main/scala/ch/epfl/scala/debugadapter/internal/stepfilter/RuntimeStepFilter.scala
@@ -8,10 +8,11 @@ private class RuntimeStepFilter(
     classesToSkip: Set[String],
     methodsToSkip: Set[String]
 ) extends StepFilter {
-  override def shouldStepInto(method: Method): Boolean =
+  override def shouldSkipOver(method: Method): Boolean =
     classesToSkip.contains(method.declaringType.name) ||
       methodsToSkip.contains(method.toString)
-  override def shouldStepOut(upperLocation: Location, method: Method): Boolean =
+
+  override def shouldSkipOut(upperLocation: Location, method: Method): Boolean =
     classesToSkip.contains(method.declaringType.name) ||
       methodsToSkip.contains(method.toString)
 }

--- a/core/src/main/scala/ch/epfl/scala/debugadapter/internal/stepfilter/Scala3StepFilter.scala
+++ b/core/src/main/scala/ch/epfl/scala/debugadapter/internal/stepfilter/Scala3StepFilter.scala
@@ -12,11 +12,13 @@ import scala.util.Try
 import java.nio.file.Path
 import scala.util.Success
 import scala.util.Failure
+import ch.epfl.scala.debugadapter.ScalaVersion
 
 class Scala3StepFilter(
+    scalaVersion: ScalaVersion,
     bridge: Any,
     skipMethod: Method
-) extends ScalaStepFilter {
+) extends ScalaStepFilter(scalaVersion) {
   override protected def skipScalaMethod(method: jdi.Method): Boolean =
     try skipMethod.invoke(bridge, method).asInstanceOf[Boolean]
     catch {
@@ -50,7 +52,7 @@ object Scala3StepFilter {
         testMode: java.lang.Boolean
       )
       val skipMethod = cls.getMethods.find(m => m.getName == "skipMethod").get
-      Success(new Scala3StepFilter(bridge, skipMethod))
+      Success(new Scala3StepFilter(debuggee.scalaVersion, bridge, skipMethod))
     } catch {
       case cause: Throwable => Failure(cause)
     }

--- a/core/src/main/scala/ch/epfl/scala/debugadapter/internal/stepfilter/ScalaStepFilter.scala
+++ b/core/src/main/scala/ch/epfl/scala/debugadapter/internal/stepfilter/ScalaStepFilter.scala
@@ -14,7 +14,7 @@ import ch.epfl.scala.debugadapter.internal.ScalaExtension.*
 trait ScalaStepFilter extends StepFilter {
   protected def skipScalaMethod(method: Method): Boolean
 
-  override def shouldStepInto(method: Method): Boolean = {
+  override def shouldSkipOver(method: Method): Boolean = {
     if (method.isBridge) true
     else if (isDynamicClass(method.declaringType)) true
     else if (isJava(method)) false

--- a/core/src/main/scala/ch/epfl/scala/debugadapter/internal/stepfilter/ScalaStepFilter.scala
+++ b/core/src/main/scala/ch/epfl/scala/debugadapter/internal/stepfilter/ScalaStepFilter.scala
@@ -10,8 +10,9 @@ import ch.epfl.scala.debugadapter.DebugTools
 import ch.epfl.scala.debugadapter.Logger
 import scala.jdk.CollectionConverters.*
 import ch.epfl.scala.debugadapter.internal.ScalaExtension.*
+import ch.epfl.scala.debugadapter.ScalaVersion
 
-trait ScalaStepFilter extends StepFilter {
+abstract class ScalaStepFilter(scalaVersion: ScalaVersion) extends StepFilter {
   protected def skipScalaMethod(method: Method): Boolean
 
   override def shouldSkipOver(method: Method): Boolean = {
@@ -19,10 +20,13 @@ trait ScalaStepFilter extends StepFilter {
     else if (isDynamicClass(method.declaringType)) true
     else if (isJava(method)) false
     else if (isConstructor(method)) false
-    else if (isLocalMethod(method))
-      !isLazyInitializer(method) && isLazyGetter(method)
+    else if (isStaticConstructor(method)) false
     else if (isAnonFunction(method)) false
+    else if (isLiftedMethod(method)) !isLazyInitializer(method) && isLazyGetter(method)
+    else if (isAnonClass(method.declaringType)) false
+    // TODO in Scala 3 we should be able to find the symbol of a local class using TASTy Query
     else if (isLocalClass(method.declaringType)) false
+    else if (scalaVersion.isScala2 && isNestedClass(method.declaringType)) false
     else if (isDefaultValue(method)) false
     else if (isTraitInitializer(method)) skipTraitInitializer(method)
     else skipScalaMethod(method)
@@ -44,7 +48,13 @@ trait ScalaStepFilter extends StepFilter {
   private def isConstructor(method: Method): Boolean =
     method.name == "<init>"
 
-  private def isLocalMethod(method: Method): Boolean =
+  private def isStaticConstructor(method: Method): Boolean =
+    method.name == "<clinit>"
+
+  private def isAnonFunction(method: Method): Boolean =
+    method.name.matches(".+\\$anonfun\\$\\d+")
+
+  private def isLiftedMethod(method: Method): Boolean =
     method.name.matches(".+\\$\\d+")
 
   private def isLazyInitializer(method: Method): Boolean =
@@ -68,14 +78,17 @@ trait ScalaStepFilter extends StepFilter {
       case _ => false
     }
 
-  private def isAnonFunction(method: Method): Boolean =
-    method.name.contains("$anonfun$")
-
   private def isDefaultValue(method: Method): Boolean =
     method.name.contains("$default$")
 
-  private def isLocalClass(tpe: ReferenceType): Boolean =
+  private def isAnonClass(tpe: ReferenceType): Boolean =
     tpe.name.contains("$anon$")
+
+  private def isLocalClass(tpe: ReferenceType): Boolean =
+    tpe.name.matches(".+\\$\\d+")
+
+  private def isNestedClass(tpe: ReferenceType): Boolean =
+    tpe.name.matches(".+\\$\\.+")
 
   private def isTraitInitializer(method: Method): Boolean =
     method.name == "$init$"
@@ -101,10 +114,10 @@ object ScalaStepFilter {
             .tryLoad(debuggee, classLoader, logger, testMode)
             .warnFailure(logger, s"Cannot load step filter for Scala ${debuggee.scalaVersion}")
         }
-        .getOrElse(fallback)
+        .getOrElse(fallback(debuggee.scalaVersion))
   }
 
-  private def fallback: StepFilter = new ScalaStepFilter {
+  private def fallback(scalaVersion: ScalaVersion): StepFilter = new ScalaStepFilter(scalaVersion) {
     override protected def skipScalaMethod(method: Method): Boolean = false
   }
 }

--- a/core/src/main/scala/ch/epfl/scala/debugadapter/internal/stepfilter/ScalaStepFilter.scala
+++ b/core/src/main/scala/ch/epfl/scala/debugadapter/internal/stepfilter/ScalaStepFilter.scala
@@ -21,6 +21,7 @@ abstract class ScalaStepFilter(scalaVersion: ScalaVersion) extends StepFilter {
     else if (isJava(method)) false
     else if (isConstructor(method)) false
     else if (isStaticConstructor(method)) false
+    else if (isAdaptedMethod(method)) true
     else if (isAnonFunction(method)) false
     else if (isLiftedMethod(method)) !isLazyInitializer(method) && isLazyGetter(method)
     else if (isAnonClass(method.declaringType)) false
@@ -56,6 +57,9 @@ abstract class ScalaStepFilter(scalaVersion: ScalaVersion) extends StepFilter {
 
   private def isLiftedMethod(method: Method): Boolean =
     method.name.matches(".+\\$\\d+")
+
+  private def isAdaptedMethod(method: Method): Boolean =
+    method.name.matches(".+\\$adapted(\\$\\d+)?")
 
   private def isLazyInitializer(method: Method): Boolean =
     method.name.contains("$lzyINIT") || method.name.contains("$lzycompute$")

--- a/core/src/main/scala/ch/epfl/scala/debugadapter/internal/stepfilter/StepFilter.scala
+++ b/core/src/main/scala/ch/epfl/scala/debugadapter/internal/stepfilter/StepFilter.scala
@@ -4,6 +4,6 @@ import com.sun.jdi.Method
 import com.sun.jdi.Location
 
 trait StepFilter {
-  def shouldStepInto(method: Method): Boolean = false
-  def shouldStepOut(upperLocation: Location, method: Method): Boolean = false
+  def shouldSkipOver(method: Method): Boolean = false
+  def shouldSkipOut(upperLocation: Location, method: Method): Boolean = false
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
 
   val asm = "org.ow2.asm" % "asm" % asmVersion
   val asmUtil = "org.ow2.asm" % "asm-util" % asmVersion
-  val javaDebug = "ch.epfl.scala" % "com-microsoft-java-debug-core" % "0.34.0+7"
+  val javaDebug = "ch.epfl.scala" % "com-microsoft-java-debug-core" % "0.34.0+8"
 
   def scalaCompiler(scalaVersion: String): ModuleID = {
     CrossVersion.partialVersion(scalaVersion) match {

--- a/tests/src/main/scala/ch/epfl/scala/debugadapter/testfmk/DebugTestSuite.scala
+++ b/tests/src/main/scala/ch/epfl/scala/debugadapter/testfmk/DebugTestSuite.scala
@@ -12,7 +12,7 @@ import ch.epfl.scala.debugadapter.Logger
 import java.net.URI
 import com.microsoft.java.debug.core.protocol.Events.OutputEvent.Category
 import munit.FunSuite
-import munit.Assertions._
+import munit.Assertions.*
 
 abstract class DebugTestSuite extends FunSuite with DebugTest {
   override def munitTimeout: Duration = 120.seconds
@@ -35,8 +35,8 @@ trait DebugTest {
       gracePeriod: Duration = 2.seconds,
       logger: Logger = NoopLogger
   ): DebugServer = {
-    val tools = DebugTools(debuggee, TestingResolver, NoopLogger)
-    DebugServer(debuggee, tools, NoopLogger, testMode = true)
+    val tools = DebugTools(debuggee, TestingResolver, logger)
+    DebugServer(debuggee, tools, logger, testMode = true)
   }
 
   def startDebugServer(
@@ -44,8 +44,8 @@ trait DebugTest {
       gracePeriod: Duration = 2.seconds,
       logger: Logger = NoopLogger
   ): DebugServer.Handler = {
-    val tools = DebugTools(debuggee, TestingResolver, NoopLogger)
-    DebugServer.start(debuggee, tools, NoopLogger)
+    val tools = DebugTools(debuggee, TestingResolver, logger)
+    DebugServer.start(debuggee, tools, logger)
   }
 
   def check(uri: URI, attach: Option[Int] = None)(steps: DebugStepAssert[?]*): Unit = {

--- a/tests/src/test/scala/ch/epfl/scala/debugadapter/ScalaDebugTests.scala
+++ b/tests/src/test/scala/ch/epfl/scala/debugadapter/ScalaDebugTests.scala
@@ -44,50 +44,8 @@ class Scala3DebugTest extends ScalaDebugTests(ScalaVersion.`3.2`) {
 
 abstract class ScalaDebugTests(val scalaVersion: ScalaVersion) extends DebugTestSuite {
   test("should support breakpoints in scala sources") {
-    val debuggee = TestingDebuggee.scalaBreakpointTest(scalaVersion)
-    val server = getDebugServer(debuggee)
-    val client = TestingDebugClient.connect(server.uri)
-    try {
-      server.connect()
-      client.initialize()
-      client.launch()
-
-      val breakpoints = client.setBreakpoints(debuggee.sourceFiles.head, Seq(5, 13, 22, 14, 9))
-      assert(breakpoints.size == 5)
-      assert(breakpoints.forall(_.verified))
-
-      client.configurationDone()
-      val stopped1 = client.stopped()
-      val threadId = stopped1.threadId
-      assert(stopped1.reason == "breakpoint")
-
-      client.continue(threadId)
-      val stopped2 = client.stopped()
-      assert(stopped2.reason == "breakpoint")
-      assert(stopped2.threadId == threadId)
-
-      client.continue(threadId)
-      val stopped3 = client.stopped()
-      assert(stopped3.reason == "breakpoint")
-      assert(stopped3.threadId == threadId)
-
-      client.continue(threadId)
-      val stopped4 = client.stopped()
-      assert(stopped4.reason == "breakpoint")
-      assert(stopped4.threadId == threadId)
-
-      client.continue(threadId)
-      val stopped5 = client.stopped()
-      assert(stopped5.reason == "breakpoint")
-      assert(stopped5.threadId == threadId)
-
-      client.continue(threadId)
-      client.exited()
-      client.terminated()
-    } finally {
-      server.close()
-      client.close()
-    }
+    implicit val debuggee = TestingDebuggee.scalaBreakpointTest(scalaVersion)
+    check(Breakpoint(5), Breakpoint(13), Breakpoint(14), Breakpoint(22), Breakpoint(9))
   }
 
   test("should support breakpoints in fully qualified classes") {

--- a/tests/src/test/scala/ch/epfl/scala/debugadapter/ScalaEvaluationTests.scala
+++ b/tests/src/test/scala/ch/epfl/scala/debugadapter/ScalaEvaluationTests.scala
@@ -1840,7 +1840,6 @@ abstract class ScalaEvaluationTests(scalaVersion: ScalaVersion) extends DebugTes
         Evaluation.success("list(0)", 1),
         Evaluation.success("x", 1),
         Breakpoint(9), // calling map
-        Breakpoint(9), // adapted lambda
         Breakpoint(9),
         Evaluation.success("x + y", 2), // finally we are into the lifted lambda x + y
         Breakpoint(8), // still in the same lifted lambda (the line position does not make any sense)
@@ -1859,17 +1858,14 @@ abstract class ScalaEvaluationTests(scalaVersion: ScalaVersion) extends DebugTes
     else
       check(
         Breakpoint(7),
-        Breakpoint(7),
         Evaluation.ignore("list(0)", 1),
         Breakpoint(8),
         Evaluation.success("list(0)", 1),
         Evaluation.success("x", 1),
-        Breakpoint(8),
         Breakpoint(9),
         Evaluation.ignore("x + y", 2),
         Breakpoint(8),
         Breakpoint(9),
-        Breakpoint(8),
         Breakpoint(8),
         Breakpoint(13),
         Evaluation.successOrIgnore("x", 1, isScala212),

--- a/tests/src/test/scala/ch/epfl/scala/debugadapter/ScalaEvaluationTests.scala
+++ b/tests/src/test/scala/ch/epfl/scala/debugadapter/ScalaEvaluationTests.scala
@@ -1345,7 +1345,7 @@ abstract class ScalaEvaluationTests(scalaVersion: ScalaVersion) extends DebugTes
          |}
          |""".stripMargin
     implicit val debuggee: TestingDebuggee = TestingDebuggee.mainClass(source, "example.Main", scalaVersion)
-    check(Breakpoint(7), Evaluation.success("msg", "Hello World!"))
+    check(Breakpoint(6), Evaluation.success("msg", "Hello World!"))
   }
 
   test("evaluate at lambda start") {


### PR DESCRIPTION
The java-debug 0.34.0+8 uses the `IStepFilterProvider` to know if a breakpoint should stop or not.