### PR TITLE
fix: use event duration instead of whole suite result's duration when making a summary

### DIFF
--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/testing/TestSuiteEvent.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/testing/TestSuiteEvent.scala
@@ -2,58 +2,6 @@ package ch.epfl.scala.debugadapter.testing
 
 import sbt.testing.{Event, Status}
 
-import scala.jdk.CollectionConverters.*
-
-trait TestSuiteEventHandler {
-  def handle(testSuiteEvent: TestSuiteEvent): Unit
-}
-
-object TestSuiteEventHandler {
-  def formatError(
-      testName: String,
-      failureMessage: String,
-      indentSize: Int
-  ): String = {
-    val indent = " " * indentSize
-    (testName, failureMessage) match {
-      case ("", failureMessage) => s"$indent* $failureMessage"
-      case (testName, "") => s"$indent* $testName"
-      case (testName, failureMessage) => s"$indent* $testName - $failureMessage"
-    }
-  }
-
-  def summarizeResults(
-      testSuiteResult: TestSuiteEvent.Results
-  ): TestSuiteSummary = {
-    val results = testSuiteResult.events.map { e =>
-      val name = TestUtils.printSelector(e.selector).getOrElse("")
-      val testResult: SingleTestSummary = e.status() match {
-        case Status.Success =>
-          SingleTestResult.Passed(name, testSuiteResult.duration)
-        case Status.Failure =>
-          val failedMsg =
-            TestUtils.printThrowable(e.throwable()).getOrElse("")
-          val formatted =
-            TestSuiteEventHandler.formatError(
-              name,
-              failedMsg,
-              indentSize = 0
-            )
-          SingleTestResult.Failed(name, testSuiteResult.duration, formatted)
-        case _ =>
-          SingleTestResult.Skipped(name)
-      }
-      testResult
-    }.asJava
-    val testResults = TestSuiteSummary(
-      testSuiteResult.testSuite,
-      testSuiteResult.duration,
-      results
-    )
-    testResults
-  }
-}
-
 sealed trait TestSuiteEvent
 object TestSuiteEvent {
   case object Done extends TestSuiteEvent

--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/testing/TestSuiteEventHandler.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/testing/TestSuiteEventHandler.scala
@@ -1,0 +1,57 @@
+package ch.epfl.scala.debugadapter.testing
+
+import sbt.testing.Status
+import scala.jdk.CollectionConverters.*
+
+trait TestSuiteEventHandler {
+  def handle(testSuiteEvent: TestSuiteEvent): Unit
+}
+
+object TestSuiteEventHandler {
+  def formatError(
+      testName: String,
+      failureMessage: String,
+      indentSize: Int
+  ): String = {
+    val indent = " " * indentSize
+    (testName, failureMessage) match {
+      case ("", failureMessage) => s"$indent* $failureMessage"
+      case (testName, "") => s"$indent* $testName"
+      case (testName, failureMessage) => s"$indent* $testName - $failureMessage"
+    }
+  }
+
+  /**
+   * Provide a summary of test suite execution based on passed TestSuiteEvent.Results parameter.
+   */
+  def summarizeResults(
+      testSuiteResult: TestSuiteEvent.Results
+  ): TestSuiteSummary = {
+    val results = testSuiteResult.events.map { e =>
+      val name = TestUtils.printSelector(e.selector).getOrElse("")
+      val testResult: SingleTestSummary = e.status() match {
+        case Status.Success =>
+          SingleTestResult.Passed(name, e.duration)
+        case Status.Failure =>
+          val failedMsg =
+            TestUtils.printThrowable(e.throwable()).getOrElse("")
+          val formatted =
+            TestSuiteEventHandler.formatError(
+              name,
+              failedMsg,
+              indentSize = 0
+            )
+          SingleTestResult.Failed(name, e.duration, formatted)
+        case _ =>
+          SingleTestResult.Skipped(name)
+      }
+      testResult
+    }.asJava
+
+    TestSuiteSummary(
+      suiteName = testSuiteResult.testSuite,
+      duration = testSuiteResult.duration,
+      tests = results
+    )
+  }
+}

--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/testing/TestSuiteSummary.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/testing/TestSuiteSummary.scala
@@ -1,11 +1,21 @@
 package ch.epfl.scala.debugadapter.testing
 
+/**
+ * Summary of test suite execution which is being send to the dap client.
+ * Because of gson serialization, this class uses Java List rather than a scala collection.
+ */
 final case class TestSuiteSummary(
     suiteName: String,
     duration: Long,
     tests: java.util.List[SingleTestSummary]
 )
 
+/**
+ * Sealed hierarchy that models 3 possible outcomes of single test case.
+ * I wanted to model this a discriminated union type and due to gson serialization,
+ * the best solution I was able to find at that moment was additional kind field.
+ * Each class has a smart constructor available in the companion objects which sets value of kind correctly.
+ */
 sealed trait SingleTestSummary
 object SingleTestResult {
   final class Passed private (


### PR DESCRIPTION
reported in https://github.com/scalameta/metals-vscode/issues/1296.

- change `testSuiteResult.duration` to `e.duration`
- extract `TestSuiteEventHandler` to separate file, I think it deserves that
- add some random thoughts scaladoc