### PR TITLE
fix: prepare for 3.0.7 by bumping java-debug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           submodules: true
       - uses: coursier/setup-action@v1.2.0
         with:
-          app: sbt
+          apps: sbt
       - run: sbt +compile
   test:
     strategy:
@@ -37,7 +37,7 @@ jobs:
     - uses: coursier/setup-action@v1.2.0
       with:
         jvm: ${{ matrix.jvm }}
-        app: sbt
+        apps: sbt
     - name: Unit tests
       run: sbt test
       shell: bash

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: coursier/setup-action@v1.2.0
       with:
         jvm: 'temurin:1.17.0.3'
-        app: sbt
+        apps: sbt
     - name: Unit tests
       run: sbt test
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
           submodules: true
       - uses: coursier/setup-action@v1.2.0
         with:
-          app: sbt
+          apps: sbt
           jvm: 'adopt:1.8.0-292'
       - run: sbt ci-release
         env:

--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,7 @@ lazy val javaDebug = project
       "com.github.sbt" % "junit-interface" % "0.13.3" % Test
     ),
     Test / fork := true,
-    version := (if (isRelease) "0.34.0+11" else "0.34.0+11-SNAPSHOT")
+    version := (if (isRelease) "0.34.0+12" else "0.34.0+12-SNAPSHOT")
   )
 
 lazy val core212 = core.jvm(Dependencies.scala212)


### PR DESCRIPTION
So this is in relation to https://github.com/scalacenter/scala-debug-adapter/issues/375. It looks like when we originally tried publishing this it failed due to flakiness on the Sonatype side. However, I tried again today and it also [failed](https://github.com/scalacenter/scala-debug-adapter/actions/runs/4016899774/jobs/6974689747#step:4:1274), but it seems valid:
```
2023-01-31 11:58:26.157Z error [SonatypeClient] [promote] Failed  - (SonatypeClient.scala:191)
2023-01-31 11:58:26.157Z error [SonatypeClient] Activity name:release, started:2023-01-31T11:58:12.127Z, stopped:2023-01-31T11:58:23.741Z  - (SonatypeClient.scala:467)
2023-01-31 11:58:26.159Z error [SonatypeClient]     Failed: RepositoryWritePolicy, failureMessage:Artifact updating: Repository ='releases:Releases' does not allow updating artifact='/ch/epfl/scala/com-microsoft-java-debug-core/0.34.0+11/com-microsoft-java-debug-core-0.34.0+11-sources.jar'  - (SonatypeClient.scala:385)
2023-01-31 11:58:26.164Z error [Sonatype] [STAGE_FAILURE] Failed to promote the repository.  - (Sonatype.scala:440)
```
The version that we have set for the `com-microsoft-java-debug-core` we've already published, so this of course will fail when trying to release. I'm not really sure why we even need to publish this module, but looking back I see preparation commits like https://github.com/scalacenter/scala-debug-adapter/commit/b6a5bf8492808bfa89aa9f912a180a401ceeb39b. So for now I think a quick fix would be to bump this version like we've done in the past, tag a new 3.0.7 and then let the release run.