### PR TITLE
Fix tests on releasing RC versions of the expresion-compiler

### DIFF
--- a/.github/workflows/release-expression-compiler.yml
+++ b/.github/workflows/release-expression-compiler.yml
@@ -1,4 +1,4 @@
-name: Manual Release
+name: Release Expression Compiler (manual)
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release-full.yml
+++ b/.github/workflows/release-full.yml
@@ -1,8 +1,10 @@
-name: Release
+name: Full Release (manual)
 on:
   workflow_dispatch:
-  push:
-    tags: ["*"]
+    inputs:
+      java-debug-version:
+        required: true
+        description: 'Go find next version at https://repo1.maven.org/maven2/ch/epfl/scala/com-microsoft-java-debug-core/'
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -16,6 +18,7 @@ jobs:
           jvm: 'adopt:1.8.0-292'
       - run: sbt ci-release
         env:
+          JAVA_DEBUG_VERSION: ${{ inputs.java-debug-version }}
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,7 @@ lazy val javaDebug = project
       "com.github.sbt" % "junit-interface" % "0.13.3" % Test
     ),
     Test / fork := true,
-    version := (if (isRelease) "0.34.0+12" else "0.34.0+12-SNAPSHOT")
+    version := Option(System.getenv("JAVA_DEBUG_VERSION")).getOrElse("0.34.0-SNAPSHOT")
   )
 
 lazy val core212 = core.jvm(Dependencies.scala212)

--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/ScalaVersion.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/ScalaVersion.scala
@@ -11,6 +11,8 @@ case class ScalaVersion(value: String) {
 
   def binaryVersion: String = if (isScala3) "3" else if (isScala213) "2.13" else "2.12"
 
+  def isRelease: Boolean = !value.contains("-")
+
   override def toString: String = value
 }
 


### PR DESCRIPTION
\+ Make the java-debug version configurable using an env var.