### PR TITLE
Add skipConfiguration param for instant startup of the debuggee

### DIFF
--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/SourceLookUpProvider.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/SourceLookUpProvider.scala
@@ -77,6 +77,9 @@ private[debugadapter] final class SourceLookUpProvider(
 }
 
 private[debugadapter] object SourceLookUpProvider {
+  def empty: SourceLookUpProvider =
+    new SourceLookUpProvider(Seq.empty, Map.empty, Map.empty)
+
   def apply(entries: Seq[ClassEntry], logger: Logger): SourceLookUpProvider = {
     val parrallelEntries = ParVector(entries*)
     val sourceFilesByEntry = parrallelEntries

--- a/modules/sbt-plugin/src/main/contraband/dap.contra
+++ b/modules/sbt-plugin/src/main/contraband/dap.contra
@@ -17,6 +17,8 @@ type DebugSessionParams {
 
   ## A language-agnostic JSON object interpreted by the server.
   data: sjsonnew.shaded.scalajson.ast.unsafe.JValue
+
+  skipConfiguration: Boolean = false
 }
 
 type ScalaMainClass {

--- a/modules/sbt-plugin/src/main/scala/ch/epfl/scala/debugadapter/sbtplugin/DebugAdapterPlugin.scala
+++ b/modules/sbt-plugin/src/main/scala/ch/epfl/scala/debugadapter/sbtplugin/DebugAdapterPlugin.scala
@@ -115,8 +115,8 @@ object DebugAdapterPlugin extends sbt.AutoPlugin {
    * }}}
    */
   def testSettings: Seq[Def.Setting[_]] = Seq(
-    startTestSuitesDebugSession := testSuitesSessionTask.evaluated,
-    startTestSuitesSelectionDebugSession := testSuitesSelectionSessionTask.evaluated,
+    startTestSuitesDebugSession := testSuitesSessionTask(convertFromArrayToTestSuites).evaluated,
+    startTestSuitesSelectionDebugSession := testSuitesSessionTask(convertToTestSuites).evaluated,
     startRemoteDebugSession := remoteSessionTask.evaluated,
     stopDebugSession := stopSessionTask.value
   )
@@ -145,7 +145,8 @@ object DebugAdapterPlugin extends sbt.AutoPlugin {
     ServerIntent.request {
       case r: JsonRpcRequestMessage if r.method == DebugSessionStart =>
         val commandLine = for {
-          params <- getDebugSessionParams(r)
+          json <- r.params.toRight(Error.paramsMissing(r.method))
+          params <- convertToParams(json)
           targetId <- singleBuildTarget(params)
           scope <- workspace
             .get(targetId)
@@ -165,15 +166,13 @@ object DebugAdapterPlugin extends sbt.AutoPlugin {
               startTestSuitesSelectionDebugSession.key
             case DataKind.ScalaAttachRemote => startRemoteDebugSession.key
           }
-          val data = params.data.map(CompactPrinter.apply).getOrElse("")
-          val project =
-            scope.project.toOption.get.asInstanceOf[ProjectRef].project
+          val project = scope.project.toOption.get.asInstanceOf[ProjectRef].project
           val config = configMap(scope.config.toOption.get).id
 
           // the project and config that correspond to the target identifier
           // the task that will create the debugee and start the debugServer
           // the data containing the debuggee parameters
-          s"$project / $config / $task $data"
+          s"$project / $config / $task ${CompactPrinter(json)}"
         }
 
         commandLine match {
@@ -204,9 +203,10 @@ object DebugAdapterPlugin extends sbt.AutoPlugin {
       val debugToolsResolver = InternalTasks.debugToolsResolver.value
       val javaOptions = (Keys.run / Keys.javaOptions).value
 
-      val debuggee = for {
+      val res = for {
         json <- jsonParser.parsed
-        params <- Converter.fromJson[ScalaMainClass](json).toEither.left.map { cause =>
+        params <- convertToParams(json)
+        mainClass <- Converter.fromJson[ScalaMainClass](params.data.get).toEither.left.map { cause =>
           Error.invalidParams(
             s"expected data of kind ${DataKind.ScalaMainClass}: ${cause.getMessage}"
           )
@@ -217,9 +217,9 @@ object DebugAdapterPlugin extends sbt.AutoPlugin {
           outputStrategy = None,
           bootJars = Vector.empty[File],
           workingDirectory = Option(workingDirectory),
-          runJVMOptions = javaOptions.toVector ++ params.jvmOptions,
+          runJVMOptions = javaOptions.toVector ++ mainClass.jvmOptions,
           connectInput = false,
-          envVars = envVars ++ params.environmentVariables
+          envVars = envVars ++ mainClass.environmentVariables
             .flatMap(_.split("=", 2).toList match {
               case key :: value :: Nil => Some(key -> value)
               case _ => None
@@ -227,7 +227,7 @@ object DebugAdapterPlugin extends sbt.AutoPlugin {
             .toMap
         )
 
-        new MainClassDebuggee(
+        val debuggee = new MainClassDebuggee(
           target,
           ScalaVersion(Keys.scalaVersion.value),
           forkOptions,
@@ -235,67 +235,28 @@ object DebugAdapterPlugin extends sbt.AutoPlugin {
           InternalTasks.libraries.value,
           InternalTasks.unmanagedEntries.value,
           InternalTasks.javaRuntime.value,
-          params.`class`,
-          params.arguments,
-          state.log
+          mainClass.`class`,
+          mainClass.arguments,
+          new LoggerAdapter(state.log)
         )
+        val skipConfiguration = params.skipConfiguration.getOrElse(false)
+        startServer(jobService, scope, state, target, debuggee, debugToolsResolver, skipConfiguration)
       }
 
-      debuggee match {
+      res match {
         case Left(error) =>
           Keys.state.value.respondError(error.code, error.message)
           throw new MessageOnlyException(error.message)
-        case Right(debuggee) =>
-          startServer(jobService, scope, state, target, debuggee, debugToolsResolver)
+        case Right(uri) => uri
       }
-    }
-
-  /**
-   * Parses arguments for ScalaTestSuites request.
-   * @param json is expected to be an array of strings
-   */
-  private def testSuitesSessionTask(): Def.Initialize[InputTask[URI]] =
-    testSuitesSessionTaskImpl { json =>
-      Converter
-        .fromJson[Array[String]](json)
-        .toEither
-        .map { names =>
-          val testSelection = names
-            .map(name => ScalaTestSuiteSelection(name, Vector.empty))
-            .toVector
-          ScalaTestSuites(testSelection, Vector.empty, Vector.empty)
-        }
-        .left
-        .map { cause =>
-          Error.invalidParams(
-            s"expected data of kind ${DataKind.ScalaTestSuites}: ${cause.getMessage}"
-          )
-        }
-    }
-
-  /**
-   * Parses arguments for ScalaTestSuitesSelection request.
-   * @param json is expected to be an instance of ScalaTestSuites
-   */
-  private def testSuitesSelectionSessionTask(): Def.Initialize[InputTask[URI]] =
-    testSuitesSessionTaskImpl { json =>
-      Converter
-        .fromJson[ScalaTestSuites](json)
-        .toEither
-        .left
-        .map { cause =>
-          Error.invalidParams(
-            s"expected data of kind ${DataKind.ScalaTestSuitesSelection}: ${cause.getMessage}"
-          )
-        }
     }
 
   /**
    * Handles debug request for both
    * ScalaTestSuites and ScalaTestSuitesSelection kinds.
    */
-  private def testSuitesSessionTaskImpl(
-      parseFn: JValue => Result[ScalaTestSuites]
+  private def testSuitesSessionTask(
+      convertToTestSuites: JValue => Result[ScalaTestSuites]
   ): Def.Initialize[InputTask[URI]] =
     Def.inputTask {
       val target = Keys.bspTargetIdentifier.value
@@ -310,9 +271,10 @@ object DebugAdapterPlugin extends sbt.AutoPlugin {
       val scope = Keys.resolvedScoped.value
       val debugToolsResolver = InternalTasks.debugToolsResolver.value
 
-      val debuggee = for {
+      val res = for {
         json <- jsonParser.parsed
-        testSuites <- parseFn(json)
+        params <- convertToParams(json)
+        testSuites <- convertToTestSuites(params.data.get)
         selectedTests = testSuites.suites
           .map(suite => (suite.className, suite.tests))
           .toMap
@@ -371,7 +333,7 @@ object DebugAdapterPlugin extends sbt.AutoPlugin {
         // unfortunately we cannot do the same for cleanup
         setups.foreach(_.setup(dummyLoader))
 
-        new TestSuitesDebuggee(
+        val debuggee = new TestSuitesDebuggee(
           target,
           ScalaVersion(Keys.scalaVersion.value),
           forkOptions,
@@ -383,16 +345,17 @@ object DebugAdapterPlugin extends sbt.AutoPlugin {
           parallel,
           testRunners,
           testDefinitions,
-          state.log
+          new LoggerAdapter(state.log)
         )
+        val skipConfiguration = params.skipConfiguration.getOrElse(false)
+        startServer(jobService, scope, state, target, debuggee, debugToolsResolver, skipConfiguration)
       }
 
-      debuggee match {
+      res match {
         case Left(error) =>
           state.respondError(error.code, error.message)
           throw new MessageOnlyException(error.message)
-        case Right(debuggee) =>
-          startServer(jobService, scope, state, target, debuggee, debugToolsResolver)
+        case Right(uri) => uri
       }
     }
 
@@ -443,9 +406,22 @@ object DebugAdapterPlugin extends sbt.AutoPlugin {
         InternalTasks.libraries.value,
         InternalTasks.unmanagedEntries.value,
         InternalTasks.javaRuntime.value,
-        state.log
+        new LoggerAdapter(state.log)
       )
-      startServer(jobService, scope, state, target, debuggee, debugToolsResolver)
+
+      val res = for {
+        json <- jsonParser.parsed
+        params <- convertToParams(json)
+      } yield {
+        val skipConfiguration = params.skipConfiguration.getOrElse(false)
+        startServer(jobService, scope, state, target, debuggee, debugToolsResolver, skipConfiguration)
+      }
+      res match {
+        case Left(error) =>
+          Keys.state.value.respondError(error.code, error.message)
+          throw new MessageOnlyException(error.message)
+        case Right(uri) => uri
+      }
     }
 
   private def startServer(
@@ -454,14 +430,20 @@ object DebugAdapterPlugin extends sbt.AutoPlugin {
       state: State,
       target: BuildTargetIdentifier,
       debuggee: SbtDebuggee,
-      resolver: DebugToolsResolver
+      resolver: DebugToolsResolver,
+      skipConfiguration: Boolean
   ): URI = {
     val address = new DebugServer.Address()
-    val tools = DebugTools(debuggee, resolver, new LoggerAdapter(state.log))
+    val tools =
+      if (skipConfiguration) {
+        state.log.info("Skipping configuration of debugger")
+        DebugTools.none
+      } else DebugTools(debuggee, resolver, debuggee.logger)
+
     jobService.runInBackground(scope, state) { (logger, _) =>
       try {
         // the state logger is closed, switch to the background job logger
-        debuggee.logger = logger
+        debuggee.logger.underlying = logger
         // if there is a server for this target then close it
         debugServers.get(target).foreach(_.close())
         val server = DebugServer(debuggee, tools, new LoggerAdapter(logger), address)
@@ -497,16 +479,45 @@ object DebugAdapterPlugin extends sbt.AutoPlugin {
     }
   }
 
-  private def getDebugSessionParams(
-      r: JsonRpcRequestMessage
-  ): Result[DebugSessionParams] = {
-    r.params match {
-      case None => Left(Error.paramsMissing(r.method))
-      case Some(value: JValue) =>
-        Converter.fromJson[DebugSessionParams](value) match {
-          case Success(params: DebugSessionParams) => Right(params)
-          case Failure(err) => Left(Error.invalidParams(err.getMessage))
-        }
+  /**
+   * Parses data for ScalaTestSuites request.
+   * @param json is expected to be an array of strings
+   */
+  private def convertFromArrayToTestSuites(json: JValue): Result[ScalaTestSuites] =
+    Converter
+      .fromJson[Array[String]](json)
+      .toEither
+      .map { names =>
+        val testSelection = names
+          .map(name => ScalaTestSuiteSelection(name, Vector.empty))
+          .toVector
+        ScalaTestSuites(testSelection, Vector.empty, Vector.empty)
+      }
+      .left
+      .map { cause =>
+        Error.invalidParams(
+          s"expected data of kind ${DataKind.ScalaTestSuites}: ${cause.getMessage}"
+        )
+      }
+
+  /**
+   * Parses arguments for ScalaTestSuitesSelection request.
+   * @param json is expected to be an instance of ScalaTestSuites
+   */
+  private def convertToTestSuites(json: JValue): Result[ScalaTestSuites] =
+    Converter
+      .fromJson[ScalaTestSuites](json)
+      .toEither
+      .left
+      .map { cause =>
+        Error.invalidParams(
+          s"expected data of kind ${DataKind.ScalaTestSuitesSelection}: ${cause.getMessage}"
+        )
+      }
+
+  private def convertToParams(json: JValue): Result[DebugSessionParams] =
+    Converter.fromJson[DebugSessionParams](json) match {
+      case Success(params: DebugSessionParams) => Right(params)
+      case Failure(err) => Left(Error.invalidParams(err.getMessage))
     }
-  }
 }

--- a/modules/sbt-plugin/src/main/scala/ch/epfl/scala/debugadapter/sbtplugin/internal/DebuggeeProcess.scala
+++ b/modules/sbt-plugin/src/main/scala/ch/epfl/scala/debugadapter/sbtplugin/internal/DebuggeeProcess.scala
@@ -2,6 +2,7 @@ package ch.epfl.scala.debugadapter.sbtplugin.internal
 
 import ch.epfl.scala.debugadapter.CancelableFuture
 import ch.epfl.scala.debugadapter.DebuggeeListener
+import ch.epfl.scala.debugadapter.Logger
 import sbt.ForkOptions
 import sbt.io.syntax._
 
@@ -41,7 +42,7 @@ private object DebuggeeProcess {
       mainClass: String,
       arguments: Seq[String],
       listener: DebuggeeListener,
-      logger: sbt.Logger
+      logger: Logger
   )(implicit ec: ExecutionContext): DebuggeeProcess = {
     val javaHome = forkOptions.javaHome.getOrElse(new File(System.getProperty("java.home")))
     val javaBin = (javaHome / "bin" / "java").getAbsolutePath

--- a/modules/sbt-plugin/src/main/scala/ch/epfl/scala/debugadapter/sbtplugin/internal/LoggerAdapter.scala
+++ b/modules/sbt-plugin/src/main/scala/ch/epfl/scala/debugadapter/sbtplugin/internal/LoggerAdapter.scala
@@ -2,7 +2,11 @@ package ch.epfl.scala.debugadapter.sbtplugin.internal
 
 import ch.epfl.scala.debugadapter.Logger
 
-private[debugadapter] class LoggerAdapter(underlying: sbt.Logger) extends Logger {
+/**
+ * Underlying logger is mutable because we use a different logger
+ * for logging during the task and during the background job
+ */
+private[debugadapter] class LoggerAdapter(var underlying: sbt.Logger) extends Logger {
   override def debug(msg: => String): Unit = ()
   override def info(msg: => String): Unit = underlying.info(msg)
   override def warn(msg: => String): Unit = underlying.warn(msg)

--- a/modules/sbt-plugin/src/main/scala/ch/epfl/scala/debugadapter/sbtplugin/internal/SbtDebuggee.scala
+++ b/modules/sbt-plugin/src/main/scala/ch/epfl/scala/debugadapter/sbtplugin/internal/SbtDebuggee.scala
@@ -15,9 +15,7 @@ import scala.util.control.NonFatal
 import ch.epfl.scala.debugadapter.testing.TestSuiteEvent
 
 private[debugadapter] sealed trait SbtDebuggee extends Debuggee {
-  // logger is mutable because we use a different logger
-  // for logging during the task and during the background job
-  var logger: sbt.Logger
+  val logger: LoggerAdapter
 }
 
 private[debugadapter] final class MainClassDebuggee(
@@ -30,7 +28,7 @@ private[debugadapter] final class MainClassDebuggee(
     val javaRuntime: Option[JavaRuntime],
     mainClass: String,
     args: Seq[String],
-    var logger: sbt.Logger
+    val logger: LoggerAdapter
 )(implicit ec: ExecutionContext)
     extends SbtDebuggee {
   override def name: String =
@@ -52,7 +50,7 @@ private[debugadapter] final class TestSuitesDebuggee(
     parallel: Boolean,
     runners: Map[TestFramework, Runner],
     tests: Seq[TestDefinition],
-    var logger: sbt.Logger
+    val logger: LoggerAdapter
 )(implicit executionContext: ExecutionContext)
     extends SbtDebuggee {
 
@@ -188,7 +186,7 @@ private[debugadapter] final class AttachRemoteDebuggee(
     val libraries: Seq[Library],
     val unmanagedEntries: Seq[UnmanagedEntry],
     val javaRuntime: Option[JavaRuntime],
-    var logger: sbt.Logger
+    val logger: LoggerAdapter
 ) extends SbtDebuggee {
   override def name: String = s"${getClass.getSimpleName}(${target.uri})"
   override def run(listener: DebuggeeListener): CancelableFuture[Unit] =

--- a/modules/sbt-plugin/src/sbt-test/debug-session/aggregate/test
+++ b/modules/sbt-plugin/src/sbt-test/debug-session/aggregate/test
@@ -1,3 +1,3 @@
-> 'root / Test / startTestSuitesDebugSession ["example.HelloSpec"]'
-> 'root / Test / startMainClassDebugSession {"class":"example.Hello","arguments":[],"jvmOptions":[]}'
+> 'root / Test / startTestSuitesDebugSession {"data":["example.HelloSpec"]}'
+> 'root / Test / startMainClassDebugSession {"data":{"class":"example.Hello","arguments":[],"jvmOptions":[]}}'
 > root / Test / stopDebugSession

--- a/modules/sbt-plugin/src/sbt-test/debug-session/attach/test
+++ b/modules/sbt-plugin/src/sbt-test/debug-session/attach/test
@@ -1,2 +1,2 @@
-> 'checkDebugSession {}'
+> 'checkDebugSession {"data":{}}'
 > stopDebugSession

--- a/modules/sbt-plugin/src/sbt-test/debug-session/integration-test-suite/test
+++ b/modules/sbt-plugin/src/sbt-test/debug-session/integration-test-suite/test
@@ -1,2 +1,2 @@
-> 'checkDebugSession ["example.MySuite"]'
+> 'checkDebugSession {"data":["example.MySuite"]}'
 > stopDebugSession

--- a/modules/sbt-plugin/src/sbt-test/debug-session/main-class-scala3/test
+++ b/modules/sbt-plugin/src/sbt-test/debug-session/main-class-scala3/test
@@ -1,2 +1,2 @@
-> 'checkDebugSession {"class":"example.Main","arguments":[],"jvmOptions":[]}'
+> 'checkDebugSession {"data":{"class":"example.Main","arguments":[],"jvmOptions":[]}}'
 > stopDebugSession

--- a/modules/sbt-plugin/src/sbt-test/debug-session/main-class/build.sbt
+++ b/modules/sbt-plugin/src/sbt-test/debug-session/main-class/build.sbt
@@ -1,10 +1,14 @@
 import ch.epfl.scala.debugadapter.testfmk._
 
-val checkDebugSession = inputKey[Unit]("Check the main class debug session")
-
 scalaVersion := "2.12.14"
-checkDebugSession := {
+InputKey[Unit]("checkDebugSession") := {
   val uri = (Compile / startMainClassDebugSession).evaluated
   val source = (Compile / sources).value.head.toPath
-  DebugTest.check(uri)(Breakpoint(source, 5))
+  DebugTest.check(uri)(Breakpoint(source, 5), Outputed("Hello, World!"))
+}
+
+InputKey[Unit]("checkDebugSessionWithSkipConfig") := {
+  val uri = (Compile / startMainClassDebugSession).evaluated
+  val source = (Compile / sources).value.head.toPath
+  DebugTest.check(uri)(Outputed("Hello, World!"))
 }

--- a/modules/sbt-plugin/src/sbt-test/debug-session/main-class/test
+++ b/modules/sbt-plugin/src/sbt-test/debug-session/main-class/test
@@ -1,2 +1,5 @@
-> 'checkDebugSession {"class":"example.Main","arguments":[],"jvmOptions":[]}'
+> 'checkDebugSession {"data":{"class":"example.Main","arguments":[],"jvmOptions":[]}}'
+> stopDebugSession
+
+> 'checkDebugSessionWithSkipConfig {"data":{"class":"example.Main","arguments":[],"jvmOptions":[]},"skipConfiguration":true}'
 > stopDebugSession

--- a/modules/sbt-plugin/src/sbt-test/debug-session/native-lib/test
+++ b/modules/sbt-plugin/src/sbt-test/debug-session/native-lib/test
@@ -1,2 +1,2 @@
-> 'checkDebugSession {"class":"example.Main","arguments":[],"jvmOptions":[]}'
+> 'checkDebugSession {"data":{"class":"example.Main","arguments":[],"jvmOptions":[]}}'
 > stopDebugSession

--- a/modules/sbt-plugin/src/sbt-test/debug-session/no-expression-compiler/test
+++ b/modules/sbt-plugin/src/sbt-test/debug-session/no-expression-compiler/test
@@ -1,2 +1,2 @@
-> 'checkDebugSession {"class":"example.Main","arguments":[],"jvmOptions":[]}'
+> 'checkDebugSession {"data":{"class":"example.Main","arguments":[],"jvmOptions":[]}}'
 > stopDebugSession

--- a/modules/sbt-plugin/src/sbt-test/debug-session/step-into-jdk/test
+++ b/modules/sbt-plugin/src/sbt-test/debug-session/step-into-jdk/test
@@ -1,2 +1,2 @@
-> 'checkDebugSession {"class":"example.Main","arguments":[],"jvmOptions":[]}'
+> 'checkDebugSession {"data":{"class":"example.Main","arguments":[],"jvmOptions":[]}}'
 > stopDebugSession

--- a/modules/sbt-plugin/src/sbt-test/debug-session/test-selection-suite/build.sbt
+++ b/modules/sbt-plugin/src/sbt-test/debug-session/test-selection-suite/build.sbt
@@ -1,15 +1,13 @@
 import ch.epfl.scala.debugadapter.testfmk._
 import munit.Assertions._
 
-val checkDebugSession = inputKey[Unit]("Check the test suite debug session")
-
 libraryDependencies += "com.github.sbt" % "junit-interface" % "0.13.3" % Test
 testFrameworks += TestFrameworks.JUnit
 scalaVersion := "2.12.14"
 
 Test / fork := true
 
-checkDebugSession := {
+InputKey[Unit]("checkDebugSession") := {
   val uri = (Test / startTestSuitesSelectionDebugSession).evaluated
 
   // Xmx is set to 1G

--- a/modules/sbt-plugin/src/sbt-test/debug-session/test-selection-suite/test
+++ b/modules/sbt-plugin/src/sbt-test/debug-session/test-selection-suite/test
@@ -1,2 +1,5 @@
-> 'checkDebugSession {"suites":[{"className":"example.TestSuite","tests":["test1"]}],"jvmOptions":["-Xmx1G"],"environmentVariables":["KEY=VALUE"]}'
+> 'checkDebugSession {"data":{"suites":[{"className":"example.TestSuite","tests":["test1"]}],"jvmOptions":["-Xmx1G"],"environmentVariables":["KEY=VALUE"]}}'
+> stopDebugSession
+
+> 'checkDebugSession {"data":{"suites":[{"className":"example.TestSuite","tests":["test1"]}],"jvmOptions":["-Xmx1G"],"environmentVariables":["KEY=VALUE"]}, "skipConfiguration":true}'
 > stopDebugSession

--- a/modules/sbt-plugin/src/sbt-test/debug-session/test-suite/test
+++ b/modules/sbt-plugin/src/sbt-test/debug-session/test-suite/test
@@ -1,2 +1,2 @@
-> 'checkDebugSession ["example.MySuite"]'
+> 'checkDebugSession {"data":["example.MySuite"]}'
 > stopDebugSession

--- a/modules/sbt-plugin/src/sbt-test/debug-session/unmanaged-jars/test
+++ b/modules/sbt-plugin/src/sbt-test/debug-session/unmanaged-jars/test
@@ -1,2 +1,2 @@
-> 'checkDebugSession {"class":"example.Main","arguments":[],"jvmOptions":[]}'
+> 'checkDebugSession {"data":{"class":"example.Main","arguments":[],"jvmOptions":[]}}'
 > stopDebugSession


### PR DESCRIPTION
When `skipConfiguration = true` the debugger skips loading the `SourceLookUpProvider` (mapping class files to source files), resolving the expression compiler and the step filter. It directly starts the debuggee (main class or test), without enable any debug feature (no breakpoint, no evaluation). It makes starting the main program or the tests a lot faster.