### PR TITLE
Module lookup fix

### DIFF
--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/EvaluationProvider.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/EvaluationProvider.scala
@@ -20,7 +20,7 @@ import ch.epfl.scala.debugadapter.internal.evaluator.MethodInvocationFailed
 import ch.epfl.scala.debugadapter.internal.evaluator.PlainLogMessage
 import ch.epfl.scala.debugadapter.internal.evaluator.PreparedExpression
 import ch.epfl.scala.debugadapter.internal.evaluator.ScalaEvaluator
-import ch.epfl.scala.debugadapter.internal.evaluator.{Recoverable, Valid, CompilerRecoverable, Fatal}
+import ch.epfl.scala.debugadapter.internal.evaluator.{Invalid, Fatal, Valid}
 import evaluator.RuntimeEvaluatorExtractors.MethodCall
 import com.microsoft.java.debug.core.IEvaluatableBreakpoint
 import com.microsoft.java.debug.core.adapter.IDebugAdapterContext
@@ -166,7 +166,7 @@ private[internal] class EvaluationProvider(
           compilePrepare(expression, frame).orElse(Success(RuntimeExpression(tree)))
         case Valid(tree) => Success(RuntimeExpression(tree))
         case Fatal(e) => Failure(e)
-        case Recoverable(_) | CompilerRecoverable(_) => compilePrepare(expression, frame)
+        case _: Invalid => compilePrepare(expression, frame)
       }
     else compilePrepare(expression, frame)
 

--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/RuntimeEvaluator.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/RuntimeEvaluator.scala
@@ -280,8 +280,8 @@ class RuntimeValidator(frame: JdiFrame, logger: Logger) {
   private def validateModule(name: String, of: Option[RuntimeTree]): Validation[ModuleTree] = {
     val moduleName = if (name.endsWith("$")) name else name + "$"
     val ofName = of.map(_.`type`.name())
-    searchAllClassesFor(moduleName, ofName, frame).flatMap { cls =>
-      val isInClass = ofName
+    searchAllClassesFor(moduleName, ofName, frame).flatMap { module =>
+      val isInCompanionClass = ofName
         .filter(_.endsWith("$"))
         .map(n => loadClass(n.stripSuffix("$"), frame))
         .map {
@@ -290,12 +290,15 @@ class RuntimeValidator(frame: JdiFrame, logger: Logger) {
           }.getResult
         }
 
-      (isInClass, cls, of) match {
+      (isInCompanionClass, module, of) match {
         case (Some(Success(cls: JdiClass)), _, _) =>
           Fatal(s"Cannot access module ${name} from ${of.map(_.`type`.name())}")
         case (_, Module(module), _) => Valid(TopLevelModuleTree(module))
-        case (_, _, Some(instance: RuntimeEvaluationTree)) => Valid(NestedModuleTree(cls, instance))
-        case _ => Recoverable(s"Cannot access module $cls")
+        case (_, _, Some(instance: RuntimeEvaluationTree)) =>
+          if (module.name().startsWith(instance.`type`.name()))
+            Valid(NestedModuleTree(module, instance))
+          else Recoverable(s"Cannot access module $module from ${instance.`type`.name()}")
+        case _ => Recoverable(s"Cannot access module $module")
       }
     }
   }
@@ -309,8 +312,8 @@ class RuntimeValidator(frame: JdiFrame, logger: Logger) {
    */
   private def validateClass(name: String, of: Option[RuntimeTree]): Validation[ClassTree] =
     searchAllClassesFor(name.stripSuffix("$"), of.map(_.`type`.name()), frame)
-      .flatMap { cls =>
-        (cls, of) match {
+      .flatMap {
+        (_, of) match {
           case (cls, Some(_: RuntimeEvaluationTree) | None) => Valid(ClassTree(cls))
           case (cls, Some(_: ClassTree)) =>
             if (cls.isStatic()) Valid(ClassTree(cls))
@@ -423,25 +426,13 @@ class RuntimeValidator(frame: JdiFrame, logger: Logger) {
       case name: Term.Name => PreparedCall(thisTree, name.value)
     }
 
-    val lhs = preparedCall.qual
-    def unary(l: RuntimeTree, name: String) =
-      l match {
-        case ret: RuntimeEvaluationTree => RuntimeUnaryOp(ret, name).map(PrimitiveUnaryOpTree(ret, _))
-        case _ => Recoverable(s"Primitive operation operand must be evaluable")
-      }
-    def binary(l: RuntimeTree, args: Seq[RuntimeEvaluationTree], name: String) =
-      (l, args) match {
-        case (ret: RuntimeEvaluationTree, Seq(right)) =>
-          RuntimeBinaryOp(ret, right, name).map(PrimitiveBinaryOpTree(ret, right, _))
-        case _ => Recoverable(s"Primitive operation operand must be evaluable")
-      }
-
     for {
-      lhs <- lhs
+      lhs <- preparedCall.qual
       args <- call.argClause.map(validate).traverse
-      methodTree <- unary(lhs, preparedCall.name)
-        .orElse(binary(lhs, args, preparedCall.name))
-        .orElse(findMethod(lhs, preparedCall.name, args))
+      methodTree <-
+        PrimitiveUnaryOpTree(lhs, preparedCall.name)
+          .orElse { PrimitiveBinaryOpTree(lhs, args, preparedCall.name) }
+          .orElse { findMethod(lhs, preparedCall.name, args) }
     } yield methodTree
   }
 

--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/RuntimeEvaluatorExtractors.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/RuntimeEvaluatorExtractors.scala
@@ -38,37 +38,6 @@ protected[internal] object RuntimeEvaluatorExtractors {
       }
   }
 
-  object Instance {
-
-    /**
-     * Allows nested modules resolution, e.g.:
-     * {{{
-     *  case class Foo() {
-     *   case class FriendFoo() {
-     *    val x = ???
-     *   }
-     * }
-     * Foo().FriendFoo().x
-     * }}}
-     */
-    def unapply(tree: RuntimeTree): Option[RuntimeEvaluationTree] =
-      tree match {
-        case _: ClassTree | _: ModuleTree | _: ThisTree => None
-        case ft: FieldTree => Some(ft)
-        case mt: MethodTree => Some(mt)
-        case lit: LiteralTree => Some(lit)
-        case lv: LocalVarTree => Some(lv)
-        case pbt: PrimitiveBinaryOpTree => Some(pbt)
-        case put: PrimitiveUnaryOpTree => Some(put)
-        case nit: NewInstanceTree => Some(nit)
-        case outer: OuterTree => Some(outer)
-      }
-
-    def unapply(tree: Option[RuntimeTree]): Option[RuntimeEvaluationTree] =
-      if (tree.isEmpty) None
-      else unapply(tree.get)
-  }
-
   object MethodCall {
     def unapply(tree: RuntimeTree): Option[RuntimeTree] =
       tree match {

--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/Validation.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/Validation.scala
@@ -65,12 +65,12 @@ final case class Recoverable(message: String) extends Invalid(new NoSuchElementE
   override def orElse[B >: Nothing](f: => Validation[B]): Validation[B] = f
 }
 
-sealed abstract class Unrecoverable(e: Exception) extends Invalid(e) {
+sealed abstract class Unrecoverable(override val exception: Exception) extends Invalid(exception) {
   override def orElse[B >: Nothing](f: => Validation[B]): Validation[B] = this
 }
 
-final case class Fatal(e: Exception) extends Unrecoverable(e)
-final case class CompilerRecoverable(e: Exception) extends Unrecoverable(e)
+final case class Fatal(override val exception: Exception) extends Unrecoverable(exception)
+final case class CompilerRecoverable(override val exception: Exception) extends Unrecoverable(exception)
 
 object Validation {
   def apply[A](input: => A): Validation[A] = {

--- a/modules/tests/src/test/scala/ch/epfl/scala/debugadapter/internal/RuntimeEvaluatorTests.scala
+++ b/modules/tests/src/test/scala/ch/epfl/scala/debugadapter/internal/RuntimeEvaluatorTests.scala
@@ -164,7 +164,6 @@ object RuntimeEvaluatorEnvironments {
        |    def greet = "Friendly"
        |    case class ObjectFriendFoo() { val str = s"object friend foo $z"}
        |    object ObjectFriendFoo { val str = s"object object friend foo $z"}
-       |
        |  }
        |  def friendFoo = FriendFoo
        |}

--- a/modules/tests/src/test/scala/ch/epfl/scala/debugadapter/internal/RuntimeEvaluatorTests.scala
+++ b/modules/tests/src/test/scala/ch/epfl/scala/debugadapter/internal/RuntimeEvaluatorTests.scala
@@ -404,8 +404,8 @@ abstract class RuntimeEvaluatorTests(val scalaVersion: ScalaVersion) extends Deb
       Breakpoint(10),
       Evaluation.failed("Foo.FriendFoo.greet"),
       Evaluation.failed("Foo.FriendFoo(Foo()).greet"),
-      Evaluation.failed("Foo().friendFoo.InnerFriendFoo.str", "Cannot access module InnerFriendFoo"),
-      Evaluation.failed("Foo().friendFoo.InnerFriendFoo().str", "Cannot access module InnerFriendFoo")
+      Evaluation.failed("Foo().friendFoo.InnerFriendFoo.str"),
+      Evaluation.failed("Foo().friendFoo.InnerFriendFoo().str")
     )
   }
 

--- a/modules/tests/src/test/scala/ch/epfl/scala/debugadapter/internal/RuntimeEvaluatorTests.scala
+++ b/modules/tests/src/test/scala/ch/epfl/scala/debugadapter/internal/RuntimeEvaluatorTests.scala
@@ -164,7 +164,9 @@ object RuntimeEvaluatorEnvironments {
        |    def greet = "Friendly"
        |    case class ObjectFriendFoo() { val str = s"object friend foo $z"}
        |    object ObjectFriendFoo { val str = s"object object friend foo $z"}
+       |
        |  }
+       |  def friendFoo = FriendFoo
        |}
        |
        |case class Nested(x: Int) {
@@ -402,12 +404,14 @@ abstract class RuntimeEvaluatorTests(val scalaVersion: ScalaVersion) extends Deb
     check(
       Breakpoint(10),
       Evaluation.failed("Foo.FriendFoo.greet"),
-      Evaluation.failed("Foo.FriendFoo(Foo()).greet")
+      Evaluation.failed("Foo.FriendFoo(Foo()).greet"),
+      Evaluation.failed("Foo().friendFoo.InnerFriendFoo.str", "Cannot access module InnerFriendFoo"),
+      Evaluation.failed("Foo().friendFoo.InnerFriendFoo().str", "Cannot access module InnerFriendFoo")
     )
   }
 
   test(
-    "Should access to multiple layers of nested types. However when the nested class take no parameters there is a conflict with its companion object"
+    "Should access to multiple layers of nested types"
   ) {
     implicit val debuggee = nested
     check(

--- a/modules/tests/src/test/scala/ch/epfl/scala/debugadapter/internal/RuntimeEvaluatorTests.scala
+++ b/modules/tests/src/test/scala/ch/epfl/scala/debugadapter/internal/RuntimeEvaluatorTests.scala
@@ -410,9 +410,7 @@ abstract class RuntimeEvaluatorTests(val scalaVersion: ScalaVersion) extends Deb
     )
   }
 
-  test(
-    "Should access to multiple layers of nested types"
-  ) {
+  test("Should access to multiple layers of nested types") {
     implicit val debuggee = nested
     check(
       Breakpoint(10),


### PR DESCRIPTION
There was a bug with my first implementation. Given the following code
```scala
case class Foo() {
  case class FriendFoo() {
    case class InnerFriendFoo() { val str = "inner friend foo"}
    object InnerFriendFoo { val str = "object inner friend foo"}
  }
  object FriendFoo
  def friendFoo = FriendFoo
}
```
Calling `Foo().friendFoo.InnerFriendFoo.str` could pass the validation even if incorrect

The reason was a bad management of module & nested type name encoding. `Foo().friendFoo` is typed as `Foo$FriendFoo$` and `Foo$FriendFoo$InnerFriendFoo$` is the encoded name of `InnerFriendFoo`. So it passed validation