### PR TITLE
Refactor ScalaStepFilterBridge and its tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -203,7 +203,7 @@ lazy val scala3StepFilter: Project = project
     scalaVersion := Dependencies.scala31Plus,
     Compile / doc / sources := Seq.empty,
     libraryDependencies ++= Seq(
-      "ch.epfl.scala" %% "tasty-query" % "0.7.9",
+      "ch.epfl.scala" %% "tasty-query" % "0.8.1",
       "org.scala-lang" %% "tasty-core" % scalaVersion.value,
       Dependencies.munit % Test
     ),

--- a/modules/scala-3-step-filter/src/test/scala/ch/epfl/scala/debugadapter/internal/stepfilter/ScalaStepFilterBridgeTests.scala
+++ b/modules/scala-3-step-filter/src/test/scala/ch/epfl/scala/debugadapter/internal/stepfilter/ScalaStepFilterBridgeTests.scala
@@ -672,6 +672,28 @@ abstract class ScalaStepFilterBridgeTests(val scalaVersion: ScalaVersion) extend
     stepFilter.assertFormat("example.Main$", "example.Foo foo()", "Main.foo: Foo[[X] =>> Either[X, Int]]")
   }
 
+  test("package object") {
+    val source =
+      """|package object example {
+         |  def foo: String = ???
+         |}
+         |""".stripMargin
+    val debuggee = TestingDebuggee.mainClass(source, "example", scalaVersion)
+    val stepFilter = getStepFilter(debuggee)
+    stepFilter.assertFormat("example.package", "java.lang.String foo()", "example.foo: String")
+  }
+
+  test("top-level definition".only) {
+    val source =
+      """|package example
+         |
+         |def foo: String = ???
+         |""".stripMargin
+    val debuggee = TestingDebuggee.mainClass(source, "example", scalaVersion)
+    val stepFilter = getStepFilter(debuggee)
+    stepFilter.assertFormat("example.example$package", "java.lang.String foo()", "example.foo: String")
+  }
+
   private def getStepFilter(debuggee: Debuggee): ScalaStepFilterBridge =
     val javaRuntimeJars = debuggee.javaRuntime.toSeq.flatMap {
       case Java8(_, classJars, _) => classJars

--- a/modules/scala-3-step-filter/src/test/scala/ch/epfl/scala/debugadapter/internal/stepfilter/ScalaStepFilterBridgeTests.scala
+++ b/modules/scala-3-step-filter/src/test/scala/ch/epfl/scala/debugadapter/internal/stepfilter/ScalaStepFilterBridgeTests.scala
@@ -683,7 +683,7 @@ abstract class ScalaStepFilterBridgeTests(val scalaVersion: ScalaVersion) extend
     stepFilter.assertFormat("example.package", "java.lang.String foo()", "example.foo: String")
   }
 
-  test("top-level definition".only) {
+  test("top-level definition") {
     val source =
       """|package example
          |

--- a/modules/scala-3-step-filter/src/test/scala/ch/epfl/scala/debugadapter/internal/stepfilter/ScalaStepFilterBridgeTests.scala
+++ b/modules/scala-3-step-filter/src/test/scala/ch/epfl/scala/debugadapter/internal/stepfilter/ScalaStepFilterBridgeTests.scala
@@ -16,10 +16,10 @@ import scala.jdk.OptionConverters.*
 
 import java.{util => ju}
 
-abstract class ScalaStepFilterBridgeTests(val scalaVersion: ScalaVersion) extends FunSuite
 class Scala30StepFilterBridgeTests extends ScalaStepFilterBridgeTests(ScalaVersion.`3.0`)
-class Scala31PlusStepFilterBridgeTests extends ScalaStepFilterBridgeTests(ScalaVersion.`3.1+`):
+class Scala31PlusStepFilterBridgeTests extends ScalaStepFilterBridgeTests(ScalaVersion.`3.1+`)
 
+abstract class ScalaStepFilterBridgeTests(val scalaVersion: ScalaVersion) extends FunSuite:
   test("mixin-forwarders") {
     val source =
       """|package example
@@ -60,35 +60,19 @@ class Scala31PlusStepFilterBridgeTests extends ScalaStepFilterBridgeTests(ScalaV
     val debuggee = TestingDebuggee.mainClass(source, "example.Main", scalaVersion)
     val stepFilter = getStepFilter(debuggee)
 
-    def findM(declaringType: String): Option[TermSymbol] =
-      stepFilter.findSymbol(FakeJdiMethod(declaringType, "m")()("java.lang.String"))
+    val javaSig = "java.lang.String m()"
 
-    def formatM(declaringType: String): Option[String] =
-      stepFilter.formatMethodSig(FakeJdiMethod(declaringType, "m")()("java.lang.String")).asScala
-
-    assert(findM("example.A").isDefined)
-    assertEquals(
-      formatM("example.A"),
-      Some("A.m(): String")
-    )
-    assert(findM("example.B").isEmpty)
-    assert(findM("example.C").isEmpty)
-    assert(findM("example.D").isDefined)
-    assertEquals(
-      formatM("example.D"),
-      Some("D.m(): String")
-    )
-    assert(findM("example.E").isEmpty)
-    assert(findM("example.F$").isEmpty)
-    assert(findM("example.Main$G").isDefined)
-    assertEquals(
-      formatM("example.Main$G"),
-      Some("Main.G.m(): String")
-    )
-    assert(findM("example.Main$H").isEmpty)
-    intercept[Exception](findM("example.Main$$anon$1"))
+    stepFilter.assertFormat("example.A", javaSig, "A.m(): String")
+    stepFilter.assertNotFound("example.B", javaSig)
+    stepFilter.assertNotFound("example.C", javaSig)
+    stepFilter.assertFormat("example.D", javaSig, "D.m(): String")
+    stepFilter.assertNotFound("example.E", javaSig)
+    stepFilter.assertNotFound("example.F$", javaSig)
+    stepFilter.assertFormat("example.Main$G", javaSig, "Main.G.m(): String")
+    stepFilter.assertNotFound("example.Main$H", javaSig)
+    stepFilter.assertFailure("example.Main$$anon$1", javaSig)
     // TODO fix: we could find it by traversing the tree of `Main`
-    intercept[Exception](findM("example.Main$$anon$2"))
+    stepFilter.assertFailure("example.Main$$anon$2", javaSig)
   }
 
   test("local classes or local objects") {
@@ -112,8 +96,8 @@ class Scala31PlusStepFilterBridgeTests extends ScalaStepFilterBridgeTests(ScalaV
          |""".stripMargin
     val debuggee = TestingDebuggee.mainClass(source, "example.Main", scalaVersion)
     val stepFilter = getStepFilter(debuggee)
-    intercept[Exception](stepFilter.findSymbol(FakeJdiMethod("example.Main$A$1", "m")()("void")))
-    intercept[Exception](stepFilter.findSymbol(FakeJdiMethod("example.Main$B$2$", "m")()("void")))
+    stepFilter.assertFailure("example.Main$A$1", "void m()")
+    stepFilter.assertFailure("example.Main$B$2$", "void m()")
   }
 
   test("getters and setters") {
@@ -149,35 +133,29 @@ class Scala31PlusStepFilterBridgeTests extends ScalaStepFilterBridgeTests(ScalaV
     val debuggee = TestingDebuggee.mainClass(source, "example.Main", scalaVersion)
     val stepFilter = getStepFilter(debuggee)
 
-    def findGetter(declaringType: String, field: String): Option[TermSymbol] =
-      stepFilter.findSymbol(FakeJdiMethod(declaringType, field)()("java.lang.String"))
-
-    def findSetter(declaringType: String, field: String): Option[TermSymbol] =
-      stepFilter.findSymbol(FakeJdiMethod(declaringType, s"$field$eq")("x$1" -> "java.lang.String")("java.lang.String"))
+    def getter(field: String): String = s"java.lang.String $field()"
+    def setter(field: String): String = s"java.lang.String $field$$eq(java.lang.String x$$1)"
 
     // When looking for a getter we find the symbol of the field
-    assert(findGetter("example.Main$", "x1").isDefined)
-    assertEquals(
-      stepFilter.formatMethodSig(FakeJdiMethod("example.Main$", "x1")()("java.lang.String")).asScala,
-      Some("Main.x1: String")
-    )
+    stepFilter.assertFind("example.Main$", getter("x1"))
+    stepFilter.assertFormat("example.Main$", getter("x1"), "Main.x1: String")
 
-    assert(findGetter("example.Main$", "x2").isDefined)
-    assert(findGetter("example.Main$", "x3").isDefined)
-    assert(findGetter("example.Main$", "x4").isDefined)
-    assert(findGetter("example.A", "a1").isDefined)
-    assert(findGetter("example.A", "a2").isDefined)
-    assert(findGetter("example.B", "b1").isDefined)
-    assert(findGetter("example.B", "b2").isDefined)
-    assert(findGetter("example.C", "c1").isDefined)
-    assert(findGetter("example.C", "c2").isDefined)
-    assert(findGetter("example.C", "c3").isDefined)
-    assert(findGetter("example.D", "d1").isDefined)
+    stepFilter.assertFind("example.Main$", getter("x2"))
+    stepFilter.assertFind("example.Main$", getter("x3"))
+    stepFilter.assertFind("example.Main$", getter("x4"))
+    stepFilter.assertFind("example.A", getter("a1"))
+    stepFilter.assertFind("example.A", getter("a2"))
+    stepFilter.assertFind("example.B", getter("b1"))
+    stepFilter.assertFind("example.B", getter("b2"))
+    stepFilter.assertFind("example.C", getter("c1"))
+    stepFilter.assertFind("example.C", getter("c2"))
+    stepFilter.assertFind("example.C", getter("c3"))
+    stepFilter.assertFind("example.D", getter("d1"))
 
     // there is no corresponding symbol in TASTy query
     // should we return the field symbol?
-    assert(findSetter("example.Main$", "x3").isEmpty)
-    assert(findSetter("example.Main$", "x4").isEmpty)
+    stepFilter.assertNotFound("example.Main$", setter("x3"))
+    stepFilter.assertNotFound("example.Main$", setter("x4"))
   }
 
   test("bridges") {
@@ -195,22 +173,11 @@ class Scala31PlusStepFilterBridgeTests extends ScalaStepFilterBridgeTests(ScalaV
     val debuggee = TestingDebuggee.mainClass(source, "example.Main", scalaVersion)
     val stepFilter = getStepFilter(debuggee)
 
-    def findM(declaringType: String, returnType: String): Option[TermSymbol] =
-      stepFilter.findSymbol(FakeJdiMethod(declaringType, "m")()(returnType))
-    def formatM(declaringType: String)(returnType: String): Option[String] =
-      stepFilter.formatMethodSig(FakeJdiMethod(declaringType, "m")()(returnType)).asScala
+    def javaSig(returnType: String): String = s"$returnType m()"
 
-    assert(findM("example.A", "java.lang.Object").isDefined)
-    assertEquals(
-      formatM("example.A")("java.lang.Object"),
-      Some("A.m(): Object")
-    )
-    assert(findM("example.B", "java.lang.Object").isEmpty)
-    assert(findM("example.B", "java.lang.String").isDefined)
-    assertEquals(
-      formatM("example.B")("java.lang.String"),
-      Some("B.m(): String")
-    )
+    stepFilter.assertFormat("example.A", javaSig("java.lang.Object"), "A.m(): Object")
+    stepFilter.assertNotFound("example.B", javaSig("java.lang.Object"))
+    stepFilter.assertFormat("example.B", javaSig("java.lang.String"), "B.m(): String")
   }
 
   test("extension method of value classes") {
@@ -232,13 +199,7 @@ class Scala31PlusStepFilterBridgeTests extends ScalaStepFilterBridgeTests(ScalaV
          |""".stripMargin
     val debuggee = TestingDebuggee.mainClass(source, "example.Main", scalaVersion)
     val stepFilter = getStepFilter(debuggee)
-    val extensionMethod =
-      FakeJdiMethod("example.A$", "m$extension")("$this" -> "java.lang.String")("java.lang.String")
-    assert(stepFilter.findSymbol(extensionMethod).isDefined)
-    assertEquals(
-      stepFilter.formatMethodSig(FakeJdiMethod("example.A$", "m$extension")()("java.lang.String")).asScala,
-      Some("A.m(): String")
-    )
+    stepFilter.assertFormat("example.A$", "java.lang.String m$extension(java.lang.String $this)", "A.m(): String")
   }
 
   test("multi parameter lists") {
@@ -255,15 +216,10 @@ class Scala31PlusStepFilterBridgeTests extends ScalaStepFilterBridgeTests(ScalaV
          |""".stripMargin
     val debuggee = TestingDebuggee.mainClass(source, "example.Main", scalaVersion)
     val stepFilter = getStepFilter(debuggee)
-    val method = FakeJdiMethod("example.Main$", "m")("a" -> "example.A")("java.lang.String")
-    assert(stepFilter.findSymbol(method).isDefined)
-    assertEquals(
-      stepFilter.formatMethodSig(method).asScala,
-      Some("Main.m()(a: A): String")
-    )
+    stepFilter.assertFormat("example.Main$", "java.lang.String m(example.A a)", "Main.m()(a: A): String")
   }
 
-  test("should step into lazy initializer") {
+  test("lazy initializer") {
     val source =
       """|package example
          |
@@ -282,14 +238,13 @@ class Scala31PlusStepFilterBridgeTests extends ScalaStepFilterBridgeTests(ScalaV
 
     val debuggee = TestingDebuggee.mainClass(source, "example.Main", scalaVersion)
     val stepFilter = getStepFilter(debuggee)
-    def findLazyVal(declaringType: String, name: String): Option[TermSymbol] =
-      stepFilter.findSymbol(FakeJdiMethod(declaringType, name)()("java.lang.String"))
-    assert(findLazyVal("example.A$", "a").isDefined)
-    assert(findLazyVal("example.A$", "b").isEmpty)
-    assert(findLazyVal("example.B", "b").isDefined)
+
+    stepFilter.assertFormat("example.A$", "java.lang.String a()", "A.a: String")
+    stepFilter.assertNotFound("example.A$", "java.lang.String b()")
+    stepFilter.assertFormat("example.B", "java.lang.String b()", "B.b: String")
   }
 
-  test("synthetic method of case class") {
+  test("synthetic methods of case class") {
     val source =
       """|package example
          |
@@ -297,62 +252,18 @@ class Scala31PlusStepFilterBridgeTests extends ScalaStepFilterBridgeTests(ScalaV
          |""".stripMargin
     val debuggee = TestingDebuggee.mainClass(source, "example.Main", scalaVersion)
     val stepFilter = getStepFilter(debuggee)
-    val toString = FakeJdiMethod("example.A", "toString")()("java.lang.String")
-    val copy = FakeJdiMethod("example.A", "copy")("a" -> "java.lang.String")("example.A")
-    val hashCode = FakeJdiMethod("example.A", "hashCode")()("int")
-    val equals = FakeJdiMethod("example.A", "equals")("x$0" -> "java.lang.Object")("boolean")
-    val productArity = FakeJdiMethod("example.A", "productArity")()("int")
-    val productPrefix = FakeJdiMethod("example.A", "productPrefix")()("java.lang.String")
-    val productElement = FakeJdiMethod("example.A", "productElement")("n" -> "int")("java.lang.Object")
-    val productIterator = FakeJdiMethod("example.A", "productIterator")()("scala.collection.Iterator")
-    val apply = FakeJdiMethod("example.A$", "apply")("a" -> "java.lang.String")("example.A")
-    val unapply = FakeJdiMethod("example.A$", "unapply")("x$1" -> "example.A")("example.A")
-    assert(stepFilter.findSymbol(toString).isDefined)
-    assertEquals(
-      stepFilter.formatMethodSig(toString).asScala,
-      Some("A.toString(): String")
-    )
-    assert(stepFilter.findSymbol(copy).isDefined)
-    assertEquals(
-      stepFilter.formatMethodSig(copy).asScala,
-      Some("A.copy(a: String): A")
-    )
-    assert(stepFilter.findSymbol(hashCode).isDefined)
-    assertEquals(
-      stepFilter.formatMethodSig(hashCode).asScala,
-      Some("A.hashCode(): Int")
-    )
-    assert(stepFilter.findSymbol(equals).isDefined)
-    assertEquals(
-      stepFilter.formatMethodSig(equals).asScala,
-      Some("A.equals(x$0: Any): Boolean")
-    )
-    assert(stepFilter.findSymbol(productArity).isDefined)
-    assertEquals(
-      stepFilter.formatMethodSig(productArity).asScala,
-      Some("A.productArity: Int")
-    )
-    assert(stepFilter.findSymbol(productPrefix).isDefined)
-    assertEquals(
-      stepFilter.formatMethodSig(productPrefix).asScala,
-      Some("A.productPrefix: String")
-    )
-    assert(stepFilter.findSymbol(productElement).isDefined)
-    assertEquals(
-      stepFilter.formatMethodSig(productElement).asScala,
-      Some("A.productElement(n: Int): Any")
-    )
-    assert(stepFilter.findSymbol(productIterator).isEmpty) // it is a bridge
-    assert(stepFilter.findSymbol(apply).isDefined)
-    assertEquals(
-      stepFilter.formatMethodSig(apply).asScala,
-      Some("A.apply(a: String): A")
-    )
-    assert(stepFilter.findSymbol(unapply).isDefined)
-    assertEquals(
-      stepFilter.formatMethodSig(unapply).asScala,
-      Some("A.unapply(x$1: A): A")
-    )
+
+    stepFilter.assertFormat("example.A", "java.lang.String toString()", "A.toString(): String")
+    stepFilter.assertFormat("example.A", "example.A copy(java.lang.String a)", "A.copy(a: String): A")
+    stepFilter.assertFormat("example.A", "int hashCode()", "A.hashCode(): Int")
+    stepFilter.assertFormat("example.A", "boolean equals(java.lang.Object x$0)", "A.equals(x$0: Any): Boolean")
+    stepFilter.assertFormat("example.A", "int productArity()", "A.productArity: Int")
+    stepFilter.assertFormat("example.A", "java.lang.String productPrefix()", "A.productPrefix: String")
+    stepFilter.assertFormat("example.A", "java.lang.Object productElement(int n)", "A.productElement(n: Int): Any")
+    stepFilter.assertNotFound("example.A", "scala.collection.Iterator productIterator()") // it is a bridge
+
+    stepFilter.assertFormat("example.A$", "example.A apply(java.lang.String a)", "A.apply(a: String): A")
+    stepFilter.assertFormat("example.A$", "example.A unapply(example.A x$1)", "A.unapply(x$1: A): A")
   }
 
   test("anonymous function") {
@@ -368,12 +279,11 @@ class Scala31PlusStepFilterBridgeTests extends ScalaStepFilterBridgeTests(ScalaV
          |""".stripMargin
     val debuggee = TestingDebuggee.mainClass(source, "example.Main", scalaVersion)
     val stepFilter = getStepFilter(debuggee)
-    val anonymousfun = FakeJdiMethod("example.Main$", "$anonfun$1")("x" -> "int")("int")
     // TODO fix: it should find the symbol f by traversing the tree of object Main
-    assert(stepFilter.findSymbol(anonymousfun).isEmpty)
+    stepFilter.assertNotFound("example.Main$", "int $anonfun$1(int x)")
   }
 
-  test("matches this.type") {
+  test("this.type") {
     val source =
       """|package example
          |
@@ -384,12 +294,7 @@ class Scala31PlusStepFilterBridgeTests extends ScalaStepFilterBridgeTests(ScalaV
 
     val debuggee = TestingDebuggee.mainClass(source, "example.Main", scalaVersion)
     val stepFilter = getStepFilter(debuggee)
-    val m = FakeJdiMethod("example.A", "m")()("example.A")
-    assert(stepFilter.findSymbol(m).isDefined)
-    assertEquals(
-      stepFilter.formatMethodSig(m).asScala,
-      Some("A.m(): A")
-    )
+    stepFilter.assertFormat("example.A", "example.A m()", "A.m(): A")
   }
 
   test("default values") {
@@ -404,16 +309,12 @@ class Scala31PlusStepFilterBridgeTests extends ScalaStepFilterBridgeTests(ScalaV
          |""".stripMargin
     val debuggee = TestingDebuggee.mainClass(source, "example.Main", scalaVersion)
     val stepFilter = getStepFilter(debuggee)
-    val mDefault1 = FakeJdiMethod("example.A", "m$default$1")()("java.lang.String")
-    val mDefault2 = FakeJdiMethod("example.A", "m$default$2")()("int")
-    val initDefault1 = FakeJdiMethod("example.A$", "$lessinit$greater$default$1")()("java.lang.String")
-    val initDefault2 = FakeJdiMethod("example.A$", "$lessinit$greater$default$2")()("int")
 
     // TODO fix: should be able to find a1, y, x and the other y by traversing the trees of m and <init>
-    assert(stepFilter.findSymbol(mDefault1).isEmpty)
-    assert(stepFilter.findSymbol(mDefault2).isEmpty)
-    assert(stepFilter.findSymbol(initDefault1).isEmpty)
-    assert(stepFilter.findSymbol(initDefault2).isEmpty)
+    stepFilter.assertNotFound("example.A", "java.lang.String m$default$1()")
+    stepFilter.assertNotFound("example.A", "int m$default$1()")
+    stepFilter.assertNotFound("example.A$", "java.lang.String $lessinit$greater$default$1()")
+    stepFilter.assertNotFound("example.A$", "int $lessinit$greater$default$2()")
   }
 
   test("matches on return types") {
@@ -430,29 +331,17 @@ class Scala31PlusStepFilterBridgeTests extends ScalaStepFilterBridgeTests(ScalaV
          |""".stripMargin
     val debuggee = TestingDebuggee.mainClass(source, "example.Main", scalaVersion)
     val stepFilter = getStepFilter(debuggee)
-    def findM(declaringType: String, returnType: String): Option[TermSymbol] =
-      stepFilter.findSymbol(FakeJdiMethod(declaringType, "m")("xs" -> "scala.collection.immutable.List")(returnType))
 
-    assert(findM("example.A", "int").isDefined)
-    assertEquals(
-      stepFilter
-        .formatMethodSig(FakeJdiMethod("example.A", "m")("xs" -> "scala.collection.immutable.List")("int"))
-        .asScala,
-      Some("A.m(xs: List[Int]): Int")
-    )
-    assert(findM("example.B", "int").isEmpty)
-    assert(findM("example.B", "java.lang.String").isDefined)
-    assertEquals(
-      stepFilter
-        .formatMethodSig(
-          (FakeJdiMethod("example.B", "m")("xs" -> "scala.collection.immutable.List")("java.lang.String"))
-        )
-        .asScala,
-      Some("B.m(xs: List[String]): String")
+    stepFilter.assertFormat("example.A", "int m(scala.collection.immutable.List xs)", "A.m(xs: List[Int]): Int")
+    stepFilter.assertNotFound("example.B", "int m(scala.collection.immutable.List xs)")
+    stepFilter.assertFormat(
+      "example.B",
+      "java.lang.String m(scala.collection.immutable.List xs)",
+      "B.m(xs: List[String]): String"
     )
   }
 
-  test("should match all kinds of types") {
+  test("all kinds of types") {
     val source: String =
       """|package example
          |
@@ -463,11 +352,6 @@ class Scala31PlusStepFilterBridgeTests extends ScalaStepFilterBridgeTests(ScalaV
          |trait A {
          |  class B
          |}
-         |class Foo {
-         |    class Bar{
-         |        
-         |}
-         |}
          |object Main extends A {
          |  def m(a : example.A): example.A = a
          |  def mbis(b: A#B): A#B = b
@@ -477,96 +361,53 @@ class Scala31PlusStepFilterBridgeTests extends ScalaStepFilterBridgeTests(ScalaV
          |  def m(x: String @annot): String @annot = x
          |  def m[T](x: T): T = x
          |  def mbis(a: Main.type): Main.type = a
-         |  def m(t: => Int ): Int = 1
-         |  def m(t : Int => Int): Int = 1
-         |  def m1(): 1&1 = 1
-         |  def m2(): 1|1 = 1
-         |  def m3(t: Int): Option[?] = Some(t)
-         |  def m4(): Foo{ type Bar} = ???
-         |  def m5(x : Foo) : x.Bar ={ 
-         |         new x.Bar()
-         |         }
-         
-         |
+         |  def m(x: => Int ): Int = 1
+         |  def m(x : Int => Int): Int = 1
+         |  def mter(x: 1&1): 1|1 = 1
+         |  def m(x: Int): Option[?] = Some(x)
+         |  def m(a: A { type B })(b: a.type): b.B = new a.B
+         |  val x: A = new A {}
+         |  def m(a: x.type)(b: x.B): A = a
          |}
          |""".stripMargin
+
     val debuggee = TestingDebuggee.mainClass(source, "example.Main", scalaVersion)
     val stepFilter = getStepFilter(debuggee)
 
-    def assertFind(name: String)(arguments: (String, String)*)(returnType: String)(using munit.Location): Unit =
-      val m = stepFilter.findSymbol(FakeJdiMethod("example.Main$", name)(arguments*)(returnType))
-      assert(m.isDefined)
-    def assertFormat(name: String)(arguments: (String, String)*)(returnType: String)(expectedFormat: String): Unit =
-      assertEquals(
-        stepFilter.formatMethodSig(FakeJdiMethod("example.Main$", name)(arguments*)(returnType)).asScala,
-        Some(expectedFormat)
-      )
+    def assertFormat(javaSig: String, expected: String)(using munit.Location): Unit =
+      stepFilter.assertFormat("example.Main$", javaSig, expected)
 
-    assertFind("m")("a" -> "example.A")("example.A")
-    assertFormat("m")("a" -> "example.A")("example.A")("Main.m(a: A): A")
-
-    assertFind("mbis")("b" -> "example.A$B")("example.A$B")
-    assertFormat("mbis")("b" -> "example.A$B")("example.A$B")("Main.mbis(b: A.B): A.B")
-
-    assertFind("mbis")("a" -> "example.A", "b" -> "example.A$B")("example.A$B")
-    assertFormat("mbis")("a" -> "example.A", "b" -> "example.A$B")("example.A$B")("Main.mbis(a: A)(b: a.B): a.B")
-
-    assertFind("m")("a" -> "example.Main$")("example.Main$")
-    assertFormat("m")("a" -> "example.Main$")("example.Main$")("Main.m(a: Main): Main")
-
-    assertFind("mbis")("a" -> "example.A")("example.A")
-    assertFormat("mbis")("a" -> "example.A")("example.A")("Main.mbis(a: A { ... }): A { ... }")
-
-    assertFind("m")("x" -> "java.lang.String")("java.lang.String")
-    assertFormat("m")("x" -> "java.lang.String")("java.lang.String")("Main.m(x: String): String")
-
-    assertFind("m")("x" -> "java.lang.Object")("java.lang.Object")
-    assertFormat("m")("x" -> "java.lang.Object")("java.lang.Object")("Main.m[T](x: T): T")
-
-    assertFind("mbis")("a" -> "example.Main$")("example.Main$")
-    assertFormat("mbis")("a" -> "example.Main$")("example.Main$")("Main.mbis(a: Main): Main")
-
-    assertFind("m")("t" -> "scala.Function0")("int")
-    assertFormat("m")("t" -> "scala.Function0")("int")("Main.m(t: => Int): Int")
-
-    assertFind("m")("t" -> "scala.Function1")("int")
-    assertFormat("m")("t" -> "scala.Function1")("int")("Main.m(t: Int => Int): Int")
-
-    assertFind("m1")()("int")
-    assertFormat("m1")()("int")("Main.m1(): 1&1")
-
-    assertFind("m2")()("int")
-    assertFormat("m2")()("int")("Main.m2(): 1|1")
-
-    assertFind("m3")("t" -> "int")("scala.Option")
-    assertFormat("m3")("t" -> "int")("scala.Option")("Main.m3(t: Int): Option[?]")
-
-    assertFind("m4")()("example.Foo")
-    assertFormat("m4")()("example.Foo")("Main.m4(): Foo { ... }")
-
-    assertFind("m5")("x" -> "example.Foo")("example.Foo$Bar")
-    assertFormat("m5")("x" -> "example.Foo")("example.Foo$Bar")("Main.m5(x: Foo): x.Bar")
+    assertFormat("example.A m(example.A a)", "Main.m(a: A): A")
+    assertFormat("example.A$B mbis(example.A$B b)", "Main.mbis(b: A.B): A.B")
+    assertFormat("example.A$B mbis(example.A a, example.A$B b)", "Main.mbis(a: A)(b: a.B): a.B")
+    assertFormat("example.Main$ m(example.Main$ a)", "Main.m(a: Main): Main")
+    assertFormat("example.A mbis(example.A a)", "Main.mbis(a: A {...}): A {...}")
+    assertFormat("java.lang.String m(java.lang.String x)", "Main.m(x: String): String")
+    assertFormat("java.lang.Object m(java.lang.Object x)", "Main.m[T](x: T): T")
+    assertFormat("example.Main$ mbis(example.Main$ a)", "Main.mbis(a: Main.type): Main.type")
+    assertFormat("int m(scala.Function0 x)", "Main.m(x: => Int): Int")
+    assertFormat("int m(scala.Function1 x)", "Main.m(x: Int => Int): Int")
+    // TODO fix: should be m
+    assertFormat("int mter(int x)", "Main.mter(x: 1 & 1): 1 | 1")
+    assertFormat("scala.Option m(int x)", "Main.m(x: Int): Option[?]")
+    assertFormat("example.A$B m(example.A a, example.A b)", "Main.m(a: A {...})(b: a.type): b.B")
+    assertFormat("example.A m(example.A a, example.A$B b)", "Main.m(a: x.type)(b: x.B): A")
   }
 
-  test("matches constant type") {
+  test("constant type") {
     val source =
       """|package example
          |
          |class A {
-         |  def m(x: "a"): 1 = 1
+         |  def m1(x: "a"): 1 = 1
          |}
          |""".stripMargin
     val debuggee = TestingDebuggee.mainClass(source, "example.Main", scalaVersion)
     val stepFilter = getStepFilter(debuggee)
-    val m = FakeJdiMethod("example.A", "m")("x" -> "java.lang.String")("int")
-    assert(stepFilter.findSymbol(m).isDefined)
-    assertEquals(
-      stepFilter.formatMethodSig(m).asScala,
-      Some("A.m(x: a): 1")
-    )
+    stepFilter.assertFormat("example.A", "int m1(java.lang.String x)", "A.m1(x: \"a\"): 1")
   }
 
-  test("matches type aliases") {
+  test("type aliases") {
     val source =
       """|package example
          |
@@ -580,15 +421,10 @@ class Scala31PlusStepFilterBridgeTests extends ScalaStepFilterBridgeTests(ScalaV
          |""".stripMargin
     val debuggee = TestingDebuggee.mainClass(source, "example.Main", scalaVersion)
     val stepFilter = getStepFilter(debuggee)
-    val m = FakeJdiMethod("example.Main$", "m")("x" -> "example.A")("java.lang.String")
-    assert(stepFilter.findSymbol(m).isDefined)
-    assertEquals(
-      stepFilter.formatMethodSig(m).asScala,
-      Some("Main.m(x: Foo): Bar")
-    )
+    stepFilter.assertFormat("example.Main$", "java.lang.String m(example.A m)", "Main.m(x: Foo): Bar")
   }
 
-  test("matches refined types") {
+  test("refined types") {
     val source =
       """|package example
          |
@@ -607,21 +443,11 @@ class Scala31PlusStepFilterBridgeTests extends ScalaStepFilterBridgeTests(ScalaV
          |""".stripMargin
     val debuggee = TestingDebuggee.mainClass(source, "example.Main", scalaVersion)
     val stepFilter = getStepFilter(debuggee)
-    val m1 = FakeJdiMethod("example.Main$", "m1")()("example.B")
-    val m2 = FakeJdiMethod("example.Main$", "m2")()("java.lang.Object")
-    assert(stepFilter.findSymbol(m1).isDefined)
-    assertEquals(
-      stepFilter.formatMethodSig(m1).asScala,
-      Some("Main.m1(): A&B { ... }")
-    )
-    assert(stepFilter.findSymbol(m2).isDefined)
-    assertEquals(
-      stepFilter.formatMethodSig(m2).asScala,
-      Some("Main.m2(): Object { ... }")
-    )
+    stepFilter.assertFormat("example.Main$", "example.B m1()", "Main.m1(): A & B {...}")
+    stepFilter.assertFormat("example.Main$", "java.lang.Object m2()", "Main.m2(): Object {...}")
   }
 
-  test("matches type parameters") {
+  test("type parameters") {
     val source =
       """|package example
          |
@@ -636,21 +462,11 @@ class Scala31PlusStepFilterBridgeTests extends ScalaStepFilterBridgeTests(ScalaV
          |""".stripMargin
     val debuggee = TestingDebuggee.mainClass(source, "example.Main", scalaVersion)
     val stepFilter = getStepFilter(debuggee)
-    val m1 = FakeJdiMethod("example.B", "m1")("x" -> "example.A")("example.A")
-    val m2 = FakeJdiMethod("example.B", "m2")("x" -> "example.A")("example.A")
-    assert(stepFilter.findSymbol(m1).isDefined)
-    assertEquals(
-      stepFilter.formatMethodSig(m1).asScala,
-      Some("B.m1(x: X): X")
-    )
-    assert(stepFilter.findSymbol(m2).isDefined)
-    assertEquals(
-      stepFilter.formatMethodSig(m2).asScala,
-      Some("B.m2[T](x: T): T")
-    )
+    stepFilter.assertFormat("example.B", "example.A m1(example.A x)", "B.m1(x: X): X")
+    stepFilter.assertFormat("example.B", "example.A m2(example.A x)", "B.m2[T](x: T): T")
   }
 
-  test("matches nested classes") {
+  test("nested classes") {
     val source =
       """|package example
          |
@@ -665,12 +481,7 @@ class Scala31PlusStepFilterBridgeTests extends ScalaStepFilterBridgeTests(ScalaV
          |""".stripMargin
     val debuggee = TestingDebuggee.mainClass(source, "example.Main", scalaVersion)
     val stepFilter = getStepFilter(debuggee)
-    val today = FakeJdiMethod("example.Main$", "today")()("scala.Enumeration$Value")
-    assert(stepFilter.findSymbol(today).isDefined)
-    assertEquals(
-      stepFilter.formatMethodSig(today).asScala,
-      Some("Main.today(): Enumeration.Value")
-    )
+    stepFilter.assertFormat("example.Main$", "scala.Enumeration$Value today()", "Main.today(): Enumeration.Value")
   }
 
   test("matches Null and Nothing") {
@@ -684,14 +495,12 @@ class Scala31PlusStepFilterBridgeTests extends ScalaStepFilterBridgeTests(ScalaV
          |""".stripMargin
     val debuggee = TestingDebuggee.mainClass(source, "example.Main", scalaVersion)
     val stepFilter = getStepFilter(debuggee)
-    def findM(argumentType: String, returnType: String): Option[TermSymbol] =
-      stepFilter.findSymbol(FakeJdiMethod("example.Main$", "m")("xs" -> argumentType)(returnType))
-    def formatM(argumentType: String, returnType: String): Option[String] =
-      stepFilter.formatMethodSig(FakeJdiMethod("example.Main$", "m")("xs" -> argumentType)(returnType)).asScala
-    assert(findM("int[]", "scala.runtime.Nothing$").isDefined)
-    assertEquals(formatM("int[]", "scala.runtime.Nothing$"), Some("Main.m(xs: Array[Int]): Nothing"))
-    assert(findM("java.lang.String[]", "scala.runtime.Null$").isDefined)
-    assertEquals(formatM("java.lang.String[]", "scala.runtime.Null$"), Some("Main.m(xs: Array[String]): Null"))
+    stepFilter.assertFormat("example.Main$", "scala.runtime.Nothing$ m(int[] xs)", "Main.m(xs: Array[Int]): Nothing")
+    stepFilter.assertFormat(
+      "example.Main$",
+      "scala.runtime.Null$ m(java.lang.String[] xs)",
+      "Main.m(xs: Array[String]): Null"
+    )
   }
 
   test("matches Array whose erasure is Object") {
@@ -704,9 +513,11 @@ class Scala31PlusStepFilterBridgeTests extends ScalaStepFilterBridgeTests(ScalaV
          |""".stripMargin
     val debuggee = TestingDebuggee.mainClass(source, "example.Main", scalaVersion)
     val stepFilter = getStepFilter(debuggee)
-    val m = FakeJdiMethod("example.Main$", "m")("xs" -> "java.lang.Object")("java.lang.Object")
-    assert(stepFilter.findSymbol(m).isDefined)
-    assertEquals(stepFilter.formatMethodSig(m).asScala, Some("Main.m[T](xs: Array[T]): Array[T]"))
+    stepFilter.assertFormat(
+      "example.Main$",
+      "java.lang.Object m(java.lang.Object xs)",
+      "Main.m[T](xs: Array[T]): Array[T]"
+    )
   }
 
   test("matches PolyType") {
@@ -719,9 +530,7 @@ class Scala31PlusStepFilterBridgeTests extends ScalaStepFilterBridgeTests(ScalaV
          |""".stripMargin
     val debuggee = TestingDebuggee.mainClass(source, "example.Main", scalaVersion)
     val stepFilter = getStepFilter(debuggee)
-    val m = FakeJdiMethod("example.A", "m")("x" -> "java.lang.Object")("java.lang.Object")
-    assert(stepFilter.findSymbol(m).isDefined)
-    assertEquals(stepFilter.formatMethodSig(m).asScala, Some("A.m[T](x: B[T]): B[T]"))
+    stepFilter.assertFormat("example.A", "java.lang.Object m(java.lang.Object x)", "A.m[T](x: B[T]): B[T]")
   }
 
   test("trait initializers") {
@@ -736,14 +545,12 @@ class Scala31PlusStepFilterBridgeTests extends ScalaStepFilterBridgeTests(ScalaV
          |""".stripMargin
     val debuggee = TestingDebuggee.mainClass(source, "example.Main", scalaVersion)
     val stepFilter = getStepFilter(debuggee)
-    val aInit = FakeJdiMethod("example.A", "$init$")("$this" -> "example.A")("void")
-    val bInit = FakeJdiMethod("example.B", "<init>")()("example.B")
     // TODO fix: should find the constructors and initializers
-    assert(stepFilter.findSymbol(aInit).isEmpty)
-    assert(stepFilter.findSymbol(bInit).isEmpty)
+    stepFilter.assertNotFound("example.A", "void $init$(example.A $this)")
+    stepFilter.assertNotFound("example.B", "example.B <init>()")
   }
 
-  test("matches vararg type") {
+  test("vararg type") {
     val source =
       """|package example
          |
@@ -753,12 +560,15 @@ class Scala31PlusStepFilterBridgeTests extends ScalaStepFilterBridgeTests(ScalaV
          |""".stripMargin
     val debuggee = TestingDebuggee.mainClass(source, "example.Main", scalaVersion)
     val stepFilter = getStepFilter(debuggee)
-    val m = FakeJdiMethod("example.A", "m")("as" -> "scala.collection.immutable.Seq")("java.lang.String")
-    assert(stepFilter.findSymbol(m).isDefined)
-    assertEquals(stepFilter.formatMethodSig(m).asScala, Some("A.m(as: <repeated>[String]): String"))
+    // TODO print String* instead of <repeated>[String]
+    stepFilter.assertFormat(
+      "example.A",
+      "java.lang.String m(scala.collection.immutable.Seq as)",
+      "A.m(as: <repeated>[String]): String"
+    )
   }
 
-  test("match encoded symbols") {
+  test("encoded symbols") {
     val source =
       """|package example
          |
@@ -773,12 +583,8 @@ class Scala31PlusStepFilterBridgeTests extends ScalaStepFilterBridgeTests(ScalaV
 
     val debuggee = TestingDebuggee.mainClass(source, "example.Main", scalaVersion)
     val stepFilter = getStepFilter(debuggee)
-    val & = FakeJdiMethod("example.Main$", "$amp")("x" -> "example.$less$greater")("java.lang.String")
-    val m = FakeJdiMethod("example.$less$greater", "m")()("example.$less$greater")
-    assert(stepFilter.findSymbol(&).isDefined)
-    assertEquals(stepFilter.formatMethodSig(&).asScala, Some("Main.&(x: <>): String"))
-    assert(stepFilter.findSymbol(m).isDefined)
-    assertEquals(stepFilter.formatMethodSig(m).asScala, Some("<>.m: <>"))
+    stepFilter.assertFormat("example.Main$", "java.lang.String $amp(example.$less$greater x)", "Main.&(x: <>): String")
+    stepFilter.assertFormat("example.$less$greater", "example.$less$greater m()", "<>.m: <>")
   }
 
   test("local recursive method") {
@@ -798,9 +604,8 @@ class Scala31PlusStepFilterBridgeTests extends ScalaStepFilterBridgeTests(ScalaV
 
     val debuggee = TestingDebuggee.mainClass(source, "example.Main", scalaVersion)
     val stepFilter = getStepFilter(debuggee)
-    val rec = FakeJdiMethod("example.Main$", "rec$1")("x" -> "int", "acc" -> "int")("int")
     // TODO fix: find rec by traversing the tree of object Main
-    assert(stepFilter.findSymbol(rec).isEmpty)
+    stepFilter.assertNotFound("example.Main$", "int rec$1(int x, int acc)")
   }
 
   test("local lazy initializer") {
@@ -820,13 +625,9 @@ class Scala31PlusStepFilterBridgeTests extends ScalaStepFilterBridgeTests(ScalaV
 
     val debuggee = TestingDebuggee.mainClass(source, "example.Main", scalaVersion)
     val stepFilter = getStepFilter(debuggee)
-    val lazyInitializer =
-      FakeJdiMethod("example.Main$", "foo$lzyINIT1$1")("foo$lzy1$1" -> "scala.runtime.LazyRef")("java.lang.String")
-    val getter =
-      FakeJdiMethod("example.Main$", "foo$1")("foo$lzy1$2" -> "scala.runtime.LazyRef")("java.lang.String")
     // TODO fix: find foo by traversing the tree of object Main
-    assert(stepFilter.findSymbol(lazyInitializer).isEmpty)
-    assert(stepFilter.findSymbol(getter).isEmpty)
+    stepFilter.assertNotFound("example.Main$", "java.lang.String foo$lzyINIT1$1(scala.runtime.LazyRef foo$lzy1$1)")
+    stepFilter.assertNotFound("example.Main$", "java.lang.String foo$1(scala.runtime.LazyRef foo$lzy1$2)")
   }
 
   test("private methods made public") {
@@ -852,35 +653,23 @@ class Scala31PlusStepFilterBridgeTests extends ScalaStepFilterBridgeTests(ScalaV
          |""".stripMargin
     val debuggee = TestingDebuggee.mainClass(source, "example.Main", scalaVersion)
     val stepFilter = getStepFilter(debuggee)
-    val foo = FakeJdiMethod("example.Outer", "example$Outer$$foo")()("java.lang.String")
-    val m = FakeJdiMethod("example.A$", "example$A$$$m")()("int")
-    assert(stepFilter.findSymbol(foo).isDefined)
-    assertEquals(stepFilter.formatMethodSig(foo).asScala, Some("Outer.foo: String"))
-    assert(stepFilter.findSymbol(m).isDefined)
-    assertEquals(stepFilter.formatMethodSig(m).asScala, Some("A.m: Int"))
-
+    stepFilter.assertFormat("example.Outer", "java.lang.String example$Outer$$foo()", "Outer.foo: String")
+    stepFilter.assertFormat("example.A$", "int example$A$$$m()", "A.m: Int")
   }
 
-  test("correctly format TypeLambda") {
+  test("type lambda") {
     val source =
       """|package example
          |
          |trait Foo[F[_]]
          |
-         |object Main {
-         |  def foo : Foo[[X] =>> Either[X,Int]] = 
-         |    ???
-         |}
-            
-        
+         |object Main:
+         |  def foo : Foo[[X] =>> Either[X, Int]] = ???
          |""".stripMargin
 
     val debuggee = TestingDebuggee.mainClass(source, "example.Main", scalaVersion)
     val stepFilter = getStepFilter(debuggee)
-    val foo = FakeJdiMethod("example.Main$", "foo")()("example.Foo")
-    assert(stepFilter.findSymbol(foo).isDefined)
-    assertEquals(stepFilter.formatMethodSig(foo).asScala, Some("Main.foo: Foo[[X] =>> Either[X,Int]]"))
-
+    stepFilter.assertFormat("example.Main$", "example.Foo foo()", "Main.foo: Foo[[X] =>> Either[X, Int]]")
   }
 
   private def getStepFilter(debuggee: Debuggee): ScalaStepFilterBridge =
@@ -891,3 +680,20 @@ class Scala31PlusStepFilterBridgeTests extends ScalaStepFilterBridgeTests(ScalaV
     }
     val debuggeeClasspath = debuggee.classPath.toArray ++ javaRuntimeJars
     new ScalaStepFilterBridge(debuggeeClasspath, println, false)
+
+  extension (stepFilter: ScalaStepFilterBridge)
+    private def assertFind(declaringType: String, javaSig: String)(using munit.Location): Unit =
+      val m = FakeJdiMethod(declaringType, javaSig)
+      assert(stepFilter.findSymbol(m).isDefined)
+
+    private def assertNotFound(declaringType: String, javaSig: String)(using munit.Location): Unit =
+      val m = FakeJdiMethod(declaringType, javaSig)
+      assert(stepFilter.findSymbol(m).isEmpty)
+
+    private def assertFailure(declaringType: String, javaSig: String)(using munit.Location): Unit =
+      val m = FakeJdiMethod(declaringType, javaSig)
+      intercept[Exception](stepFilter.findSymbol(m))
+
+    private def assertFormat(declaringType: String, javaSig: String, expected: String)(using munit.Location): Unit =
+      val m = FakeJdiMethod(declaringType, javaSig)
+      assertEquals(stepFilter.formatMethodSig(m).asScala, Some(expected))

--- a/modules/tests/src/main/scala/ch/epfl/scala/debugadapter/testfmk/DebugStepAssert.scala
+++ b/modules/tests/src/main/scala/ch/epfl/scala/debugadapter/testfmk/DebugStepAssert.scala
@@ -161,7 +161,7 @@ object Evaluation {
   }
 
   private def assertFailed(response: Either[String, String]): Unit =
-    assert(response.isLeft, clue = s"Expected error, got ${response.right.get}$RESET")
+    assert(response.isLeft, clue = s"Expected error, got ${response.right.toOption.get}$RESET")
 
   private def assertFailed(assertion: String => Unit)(response: Either[String, String]): Unit = {
     assertFailed(response)

--- a/modules/tests/src/main/scala/ch/epfl/scala/debugadapter/testfmk/FakeJdiLocalVariable.scala
+++ b/modules/tests/src/main/scala/ch/epfl/scala/debugadapter/testfmk/FakeJdiLocalVariable.scala
@@ -7,17 +7,17 @@ final case class FakeJdiLocalVariable(
     override val `type`: Type
 ) extends LocalVariable {
 
-  override def virtualMachine(): VirtualMachine = ???
+  override def virtualMachine: VirtualMachine = ???
 
   override def compareTo(o: LocalVariable): Int = ???
 
-  override def typeName(): String = ???
+  override def typeName: String = ???
 
-  override def signature(): String = ???
+  override def signature: String = ???
 
-  override def genericSignature(): String = ???
+  override def genericSignature: String = ???
 
   override def isVisible(frame: StackFrame): Boolean = ???
 
-  override def isArgument(): Boolean = ???
+  override def isArgument: Boolean = ???
 }

--- a/modules/tests/src/main/scala/ch/epfl/scala/debugadapter/testfmk/FakeJdiMethod.scala
+++ b/modules/tests/src/main/scala/ch/epfl/scala/debugadapter/testfmk/FakeJdiMethod.scala
@@ -78,13 +78,24 @@ final case class FakeJdiMethod(
 }
 
 object FakeJdiMethod {
-  def apply(declaringType: String, name: String)(arguments: (String, String)*)(
-      returnType: String = "void"
-  ): FakeJdiMethod =
-    FakeJdiMethod(
-      FakeJdiType(declaringType),
-      name,
-      arguments.map { case (name, typ) => FakeJdiLocalVariable(name, FakeJdiType(typ)): LocalVariable }.toList.asJava,
-      FakeJdiType(returnType)
-    )
+
+  def apply(declaringType: String, javaSig: String): FakeJdiMethod = {
+    val parts = javaSig.split(Array('(', ')', ',')).filter(_.nonEmpty)
+
+    def typeAndName(p: String): (String, String) = {
+      val parts = p.split(' ').filter(_.nonEmpty)
+      assert(parts.size == 2)
+      (parts(0), parts(1))
+    }
+
+    val (returnType, name) = typeAndName(parts(0))
+    val args = parts
+      .drop(1)
+      .map { p =>
+        val (tpe, name) = typeAndName(p)
+        FakeJdiLocalVariable(name, FakeJdiType(tpe)): LocalVariable
+      }
+    FakeJdiMethod(FakeJdiType(declaringType), name, args.toList.asJava, FakeJdiType(returnType))
+  }
+
 }


### PR DESCRIPTION
- Fix formatting of `TermRef` from `x` to `x.type`
- Refactor formatting in `ScalaStepFilterBridge` and `ScalaStepFilterBridgeTests`
- Add formatting of package objects and top level definitions

@aymanelamyaghri FYI I implemented the formatting of package object and top level definitions.