### PR TITLE
Evaluate flow control

### DIFF
--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/RuntimeDefaultEvaluator.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/RuntimeDefaultEvaluator.scala
@@ -21,6 +21,7 @@ class RuntimeDefaultEvaluator(val frame: JdiFrame, val logger: Logger) extends R
       case instance: NewInstanceTree => instantiate(instance)
       case method: InstanceMethodTree => invoke(method)
       case array: ArrayElemTree => evaluateArrayElement(array)
+      case branching: IfTree => evaluateIf(branching)
       case staticMethod: StaticMethodTree => invokeStatic(staticMethod)
       case outer: OuterTree => evaluateOuter(outer)
     }
@@ -120,6 +121,15 @@ class RuntimeDefaultEvaluator(val frame: JdiFrame, val logger: Logger) extends R
       array <- eval(tree.array)
       index <- eval(tree.index).flatMap(_.unboxIfPrimitive).flatMap(_.toInt)
     } yield array.asArray.getValue(index)
+
+  /* -------------------------------------------------------------------------- */
+  /*                             If tree evaluation                             */
+  /* -------------------------------------------------------------------------- */
+  def evaluateIf(tree: IfTree): Safe[JdiValue] =
+    for {
+      predicate <- eval(tree.p).flatMap(_.unboxIfPrimitive).flatMap(_.toBoolean)
+      value <- if (predicate) eval(tree.thenp) else eval(tree.elsep)
+    } yield value
 }
 
 object RuntimeDefaultEvaluator {

--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/RuntimeDefaultValidator.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/RuntimeDefaultValidator.scala
@@ -31,12 +31,13 @@ class RuntimeDefaultValidator(val frame: JdiFrame, val logger: Logger) extends R
 
   def validate(expression: Stat): Validation[RuntimeEvaluableTree] =
     expression match {
+      case lit: Lit => validateLiteral(lit)
       case value: Term.Name => validateName(value.value, thisTree)
       case _: Term.This => thisTree
       case sup: Term.Super => Recoverable("Super not (yet) supported at runtime")
       case _: Term.Apply | _: Term.ApplyInfix | _: Term.ApplyUnary => validateMethod(extractCall(expression))
       case select: Term.Select => validateSelect(select)
-      case lit: Lit => validateLiteral(lit)
+      case branch: Term.If => validateIf(branch)
       case instance: Term.New => validateNew(instance)
       case _ => Recoverable("Expression not supported at runtime")
     }
@@ -55,10 +56,10 @@ class RuntimeDefaultValidator(val frame: JdiFrame, val logger: Logger) extends R
   /* -------------------------------------------------------------------------- */
   /*                             Literal validation                             */
   /* -------------------------------------------------------------------------- */
-  def validateLiteral(lit: Lit): Validation[LiteralTree] =
+  def validateLiteral(lit: Lit): Validation[RuntimeEvaluableTree] =
     frame.classLoader().map(loader => LiteralTree(fromLitToValue(lit, loader))).extract match {
       case Success(value) => value
-      case Failure(e) => Fatal(e)
+      case Failure(e) => CompilerRecoverable(e)
     }
 
   /* -------------------------------------------------------------------------- */
@@ -251,6 +252,20 @@ class RuntimeDefaultValidator(val frame: JdiFrame, val logger: Logger) extends R
       outer <- outerLookup(ref)
       outerTree <- OuterTree(tree, outer)
     } yield outerTree
+  }
+
+  /* -------------------------------------------------------------------------- */
+  /*                           Flow control validation                          */
+  /* -------------------------------------------------------------------------- */
+
+  def validateIf(tree: Term.If): Validation[RuntimeEvaluableTree] = {
+    lazy val objType = loadClass("java.lang.Object").extract.get.cls
+    for {
+      cond <- validate(tree.cond)
+      thenp <- validate(tree.thenp)
+      elsep <- validate(tree.elsep)
+      ifTree <- IfTree(cond, thenp, elsep, isAssignableFrom(_, _), objType)
+    } yield ifTree
   }
 }
 

--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/RuntimeDefaultValidator.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/RuntimeDefaultValidator.scala
@@ -264,7 +264,13 @@ class RuntimeDefaultValidator(val frame: JdiFrame, val logger: Logger) extends R
       cond <- validate(tree.cond)
       thenp <- validate(tree.thenp)
       elsep <- validate(tree.elsep)
-      ifTree <- IfTree(cond, thenp, elsep, isAssignableFrom(_, _), objType)
+      ifTree <- IfTree(
+        cond,
+        thenp,
+        elsep,
+        isAssignableFrom(_, _),
+        extractCommonType(thenp.`type`, elsep.`type`).getOrElse(objType)
+      )
     } yield ifTree
   }
 }

--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/RuntimeDefaultValidator.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/RuntimeDefaultValidator.scala
@@ -276,7 +276,7 @@ class RuntimeDefaultValidator(val frame: JdiFrame, val logger: Logger) extends R
         thenp,
         elsep,
         isAssignableFrom(_, _),
-        extractCommonType(thenp.`type`, elsep.`type`).getOrElse(objType)
+        extractCommonSuperClass(thenp.`type`, elsep.`type`).getOrElse(objType)
       )
     } yield ifTree
   }

--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/RuntimeEvaluation.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/RuntimeEvaluation.scala
@@ -47,7 +47,7 @@ trait RuntimeValidator {
    */
   protected def validateWithClass(expression: Stat): Validation[RuntimeTree]
 
-  def validateLiteral(lit: Lit): Validation[LiteralTree]
+  def validateLiteral(lit: Lit): Validation[RuntimeEvaluableTree]
 
   def localVarTreeByName(name: String): Validation[RuntimeEvaluableTree]
 

--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/RuntimeEvaluationHelpers.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/RuntimeEvaluationHelpers.scala
@@ -253,7 +253,7 @@ private[evaluator] class RuntimeEvaluationHelpers(frame: JdiFrame) {
       }
   }
 
-  def validateType(tpe: MType, thisTypeName: Option[String])(
+  def validateType(tpe: MType, thisType: Option[RuntimeEvaluableTree])(
       termValidation: Term => Validation[RuntimeEvaluableTree]
   ): Validation[(Option[RuntimeEvaluableTree], ClassTree)] =
     tpe match {

--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/RuntimeEvaluationHelpers.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/RuntimeEvaluationHelpers.scala
@@ -11,6 +11,7 @@ import scala.meta.{Type => MType}
 import scala.util.Failure
 import scala.util.Try
 import scala.jdk.CollectionConverters.*
+import scala.annotation.tailrec
 
 private[evaluator] class RuntimeEvaluationHelpers(frame: JdiFrame) {
   import RuntimeEvaluationHelpers.*
@@ -215,7 +216,44 @@ private[evaluator] class RuntimeEvaluationHelpers(frame: JdiFrame) {
 
     loop(qual)
   }
-  def validateType(tpe: MType, thisType: Option[RuntimeEvaluableTree])(
+
+  @tailrec
+  private def getAncestors(
+      of: Type,
+      depth: Int = 0,
+      acc: List[(ClassType, Int)] = List()
+  ): List[(ReferenceType, Int)] = {
+    of match {
+      case cls: ClassType =>
+        val spr = cls.superclass()
+        if (spr != null) getAncestors(spr, depth + 1, (cls, depth) :: acc)
+        else (cls, depth) :: acc
+      case _ => acc
+    }
+  }
+
+  def extractCommonType(tpe1: Type, tpe2: Type): Option[Type] = {
+    lazy val commonAncestors = for {
+      ancestors1 <- getAncestors(tpe1)
+      ancestors2 <- getAncestors(tpe2)
+      if ancestors1._1.equals(ancestors2._1)
+    } yield (ancestors1, ancestors2)
+
+    if (tpe1.equals(tpe2)) Some(tpe1)
+    else if (commonAncestors.isEmpty) None
+    else
+      Some {
+        commonAncestors
+          .reduce { (acc, elem) =>
+            if (acc._1._2 < elem._1._2 && acc._2._2 < elem._2._2) acc
+            else elem
+          }
+          ._1
+          ._1
+      }
+  }
+
+  def validateType(tpe: MType, thisTypeName: Option[String])(
       termValidation: Term => Validation[RuntimeEvaluableTree]
   ): Validation[(Option[RuntimeEvaluableTree], ClassTree)] =
     tpe match {

--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/RuntimePreEvaluationValidator.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/RuntimePreEvaluationValidator.scala
@@ -16,9 +16,6 @@ class RuntimePreEvaluationValidator(
     Validation.fromTry(tpe).map(PreEvaluatedTree(value, _))
   }
 
-  override lazy val thisTree: Validation[PreEvaluatedTree] =
-    ThisTree(frame.thisObject).flatMap(preEvaluate)
-
   override def validateLiteral(lit: Lit): Validation[RuntimeEvaluableTree] =
     super.validateLiteral(lit).flatMap(preEvaluate)
 

--- a/modules/tests/src/test/scala/ch/epfl/scala/debugadapter/internal/JavaRuntimeEvaluatorTests.scala
+++ b/modules/tests/src/test/scala/ch/epfl/scala/debugadapter/internal/JavaRuntimeEvaluatorTests.scala
@@ -247,7 +247,7 @@ class JavaRuntimeEvaluatorTests extends DebugTestSuite {
     check(
       Breakpoint(17),
       DebugStepAssert.inParallel(
-        Evaluation.failed("coucou", "Accessing static field"),
+        Evaluation.failed("coucou"),
         Evaluation.success("lapin", "lapin"),
         Evaluation.success("love", "love")
       )
@@ -272,13 +272,13 @@ class JavaRuntimeEvaluatorTests extends DebugTestSuite {
       Breakpoint(11),
       DebugStepAssert.inParallel(
         Evaluation.success("inner.helloInner()", "hello inner 42"),
-        Evaluation.failed("inner.helloInner", "Accessing static field"),
+        Evaluation.failed("inner.helloInner"),
         Evaluation.success("Main.StaticInner.z", 84),
         Evaluation.success("Foo.StaticFriendFoo.z", 168),
-        Evaluation.failed("foo.friendFoo(new Foo()).z", "Accessing static field"),
+        Evaluation.failed("foo.friendFoo(new Foo()).z"),
         Evaluation.failed("foo.friendFoo(new Foo()).staticMethod()"),
         Evaluation.success("new Foo().friendFoo(new Foo()).y", 42),
-        Evaluation.failed("new Foo().friendFoo(new Foo()).greet", "Accessing static field"),
+        Evaluation.failed("new Foo().friendFoo(new Foo()).greet"),
         Evaluation.success("Main.StaticInner.StaticDoubleInner.z", 168)
       )
     )
@@ -289,11 +289,11 @@ class JavaRuntimeEvaluatorTests extends DebugTestSuite {
     check(
       Breakpoint(13),
       DebugStepAssert.inParallel(
-        Evaluation.failed("main.coucou", "Accessing static field"),
-        Evaluation.failed("hiddenFoo.foofoo", "Accessing static field"),
-        Evaluation.failed("foo.foofoo", "Accessing static field"),
-        Evaluation.failed("superfoo.foofoo", "Accessing static field"),
-        Evaluation.failed("main.staticMethod()", "Accessing static method")
+        Evaluation.failed("main.coucou"),
+        Evaluation.failed("hiddenFoo.foofoo"),
+        Evaluation.failed("foo.foofoo"),
+        Evaluation.failed("superfoo.foofoo"),
+        Evaluation.failed("main.staticMethod()")
       )
     )
 

--- a/modules/tests/src/test/scala/ch/epfl/scala/debugadapter/internal/RuntimeEvaluatorTests.scala
+++ b/modules/tests/src/test/scala/ch/epfl/scala/debugadapter/internal/RuntimeEvaluatorTests.scala
@@ -776,7 +776,8 @@ abstract class RuntimeEvaluatorTests(val scalaVersion: ScalaVersion) extends Deb
         Evaluation.success("(if(true) Test(-1) else x).i", -1),
         Evaluation.success("(if(false) x else Test(-1)).i", -1),
         Evaluation.failed("test(if(Test(-1).i == -1) Test(-1) else x)"),
-        Evaluation.success("(if (isTrue) new B else new C).x", "a")
+        Evaluation.success("(if (isTrue) new B else new C).x", "a"),
+        Evaluation.failed("(if (isTrue) 1 else \"a string\").x")
       )
     )
   }

--- a/modules/tests/src/test/scala/ch/epfl/scala/debugadapter/internal/RuntimeEvaluatorTests.scala
+++ b/modules/tests/src/test/scala/ch/epfl/scala/debugadapter/internal/RuntimeEvaluatorTests.scala
@@ -246,6 +246,117 @@ object RuntimeEvaluatorEnvironments {
        |  def test(i: java.lang.Integer): String = "boxed int"
        |}
        |""".stripMargin
+
+  val arraysSource =
+    """|package example
+       |
+       |object Main {
+       |  def main(args: Array[String]): Unit = {
+       |    val arr = Array(1, 2, 3)
+       |    val sh: Short = 2
+       |    val ch: Char = 2
+       |    val by: Byte = 2
+       |    println("ok")
+       |  }
+       |
+       |  def test(arr: Array[Int]): String = arr.mkString(",")
+       |
+       |  def test(arr: Array[Test]): String = arr.map(_.i).mkString(",")
+       |
+       |  case class Test(i: Int)
+       |}
+       |""".stripMargin
+  val collectionSource =
+    """|package example
+       |
+       |object Main {
+       |  def main(args: Array[String]): Unit = {
+       |    val list = List(1, 2, 3)
+       |    val map = Map(1 -> "one", 2 -> "two")
+       |    val set = Set(1, 2, 3)
+       |    val seq = Seq(1, 2, 3)
+       |    val vector = Vector(1, 2, 3)
+       |    println("ok")
+       |  } 
+       |}
+       |""".stripMargin
+
+  val innerInstantiation =
+    """|package example
+       |
+       |class A {
+       |  class AA {
+       |    class AAA(val x: Int)
+       |  }
+       |  object AA {
+       |    class StaticAAA
+       |  }
+       |}
+       |
+       |object A {
+       |  class StaticAA {
+       |    class AAA
+       |  }
+       |  object StaticAA {
+       |    class StaticAAA
+       |  }
+       |}
+       |
+       |object Main {
+       |  val AStaticAA = new A.StaticAA
+       |  def main(args: Array[String]): Unit = {
+       |    val a = new A
+       |    val aAA = new a.AA
+       |    val aAAaaa1 = new aAA.AAA(42)
+       |    val aAAaaa2 = new aAA.AAA(43)
+       |    println("ok")
+       |  }
+       |}
+       |""".stripMargin
+
+  val outerPreEval =
+    """|package example
+       |
+       |class A {
+       |  val x = 42
+       |  class C
+       |  object C { def life = x }
+       |}
+       |
+       |class B extends A {
+       |  val y = 43
+       |}
+       |
+       |object B extends A {
+       |  val y = 84
+       |}
+       |
+       |object Main {
+       |  def main(args: Array[String]): Unit = {
+       |    val b = new B
+       |    val bc = new b.C
+       |    val bC = b.C
+       |    val Bc = new B.C
+       |    val BC = B.C
+       |    println("ok")
+       |  }
+       |}
+       |""".stripMargin
+  val flowControl =
+    """|package example
+       |
+       |object Main {
+       |  def main(args: Array[String]): Unit = {
+       |    val x = 1
+       |    val t = Test(-1)
+       |    println("ok")
+       |  }
+       |
+       |  def test(x: Int): String = s"int $x"
+       |  def test(t: Test): String = s"test ${t.i}"
+       |
+       |  case class Test(i: Int)
+       |}""".stripMargin
 }
 
 abstract class RuntimeEvaluatorTests(val scalaVersion: ScalaVersion) extends DebugTestSuite {
@@ -259,6 +370,16 @@ abstract class RuntimeEvaluatorTests(val scalaVersion: ScalaVersion) extends Deb
   lazy val cls = TestingDebuggee.mainClass(RuntimeEvaluatorEnvironments.cls, "example.Main", scalaVersion)
   lazy val boxingOverloads =
     TestingDebuggee.mainClass(RuntimeEvaluatorEnvironments.boxingOverloads, "example.Main", scalaVersion)
+  lazy val arrays =
+    TestingDebuggee.mainClass(RuntimeEvaluatorEnvironments.arraysSource, "example.Main", scalaVersion)
+  lazy val collections =
+    TestingDebuggee.mainClass(RuntimeEvaluatorEnvironments.collectionSource, "example.Main", scalaVersion)
+  lazy val inners =
+    TestingDebuggee.mainClass(RuntimeEvaluatorEnvironments.innerInstantiation, "example.Main", scalaVersion)
+  lazy val outerPreEval =
+    TestingDebuggee.mainClass(RuntimeEvaluatorEnvironments.outerPreEval, "example.Main", scalaVersion)
+  lazy val controlFlow =
+    TestingDebuggee.mainClass(RuntimeEvaluatorEnvironments.flowControl, "example.Main", scalaVersion)
 
   protected override def defaultConfig: DebugConfig =
     super.defaultConfig.copy(evaluationMode = DebugConfig.RuntimeEvaluationOnly)
@@ -398,20 +519,7 @@ abstract class RuntimeEvaluatorTests(val scalaVersion: ScalaVersion) extends Deb
   }
 
   test("Should work on arrays") {
-    val arraysSource =
-      """|package example
-         |
-         |object Main {
-         |  def main(args: Array[String]): Unit = {
-         |    val arr = Array(1, 2, 3)
-         |    val sh: Short = 2
-         |    val ch: Char = 2
-         |    val by: Byte = 2
-         |    println("ok")
-         |  }
-         |}
-         |""".stripMargin
-    implicit val debuggee = TestingDebuggee.mainClass(arraysSource, "example.Main", scalaVersion)
+    implicit val debuggee = arrays
     check(
       Breakpoint(9),
       Evaluation.success("arr(0)", 1),
@@ -421,26 +529,14 @@ abstract class RuntimeEvaluatorTests(val scalaVersion: ScalaVersion) extends Deb
       Evaluation.success("arr(by)", 3),
       Evaluation.success("arr(new Integer(2))", 3),
       Evaluation.success("arr(new Character('\u0000'))", 1),
-      Evaluation.failed("arr(3)")
+      Evaluation.failed("arr(3)"),
+      Evaluation.success("test(arr)", "1,2,3"),
+      Evaluation.failed("test(Array(Test(1), Test(2), Test(3)))")
     )
   }
 
   test("Should work on collections") {
-    val collectionSource =
-      """|package example
-         |
-         |object Main {
-         |  def main(args: Array[String]): Unit = {
-         |    val list = List(1, 2, 3)
-         |    val map = Map(1 -> "one", 2 -> "two")
-         |    val set = Set(1, 2, 3)
-         |    val seq = Seq(1, 2, 3)
-         |    val vector = Vector(1, 2, 3)
-         |    println("ok")
-         |  } 
-         |}
-         |""".stripMargin
-    implicit val debuggee = TestingDebuggee.mainClass(collectionSource, "example.Main", scalaVersion)
+    implicit val debuggee = collections
     check(
       Breakpoint(10),
       Evaluation.success("list(0).toString", "1"),
@@ -624,96 +720,49 @@ abstract class RuntimeEvaluatorTests(val scalaVersion: ScalaVersion) extends Deb
   }
 
   test("Should instantiate inner classes") {
-    val source =
-      """|package example
-         |
-         |class A {
-         |  val test = {
-         |    42
-         |    println("ok")
-         |  }
-         |  class AA {
-         |    class AAA(val x: Int)
-         |  }
-         |  object AA {
-         |    class StaticAAA
-         |  }
-         |}
-         |
-         |object A {
-         |  class StaticAA {
-         |    class AAA
-         |  }
-         |  object StaticAA {
-         |    class StaticAAA
-         |  }
-         |}
-         |
-         |object Main {
-         |  val AStaticAA = new A.StaticAA
-         |  def main(args: Array[String]): Unit = {
-         |    val a = new A
-         |    a.test
-         |    val aAA = new a.AA
-         |    val aAAaaa1 = new aAA.AAA(42)
-         |    val aAAaaa2 = new aAA.AAA(43)
-         |    println("ok")
-         |  }
-         |}
-         |""".stripMargin
-    implicit val debuggee = TestingDebuggee.mainClass(source, "example.Main", scalaVersion)
+    implicit val debuggee = inners
     check(
-      Breakpoint(6),
-      Evaluation.success("new AA", ObjectRef("A$AA")),
-      Breakpoint(33),
-      Evaluation.success("new a.AA", ObjectRef("A$AA")),
-      Evaluation.success("new aAA.AAA(42)", ObjectRef("A$AA$AAA")),
-      Evaluation.success("new a.AA.StaticAAA", ObjectRef("A$AA$StaticAAA")),
-      Evaluation.success("new A.StaticAA", ObjectRef("A$StaticAA")),
-      Evaluation.success("new AStaticAA.AAA", ObjectRef("A$StaticAA$AAA")),
-      Evaluation.success("new this.AStaticAA.AAA", ObjectRef("A$StaticAA$AAA")),
-      Evaluation.success("new A.StaticAA.StaticAAA", ObjectRef("A$StaticAA$StaticAAA")),
-      Evaluation.success("aAAaaa1.x", 42),
-      Evaluation.success("aAAaaa2.x", 43)
+      Breakpoint(28),
+      DebugStepAssert.inParallel(
+        Evaluation.success("new a.AA") { res => res.startsWith("A$AA@") },
+        Evaluation.success("new aAA.AAA(42)") { res => res.startsWith("A$AA$AAA@") },
+        Evaluation.success("new a.AA.StaticAAA") { res => res.startsWith("A$AA$StaticAAA@") },
+        Evaluation.success("new A.StaticAA") { res => res.startsWith("A$StaticAA@") },
+        Evaluation.success("new AStaticAA.AAA") { res => res.startsWith("A$StaticAA$AAA@") },
+        Evaluation.success("new this.AStaticAA.AAA") { res => res.startsWith("A$StaticAA$AAA@") },
+        Evaluation.success("new A.StaticAA.StaticAAA") { res => res.startsWith("A$StaticAA$StaticAAA@") },
+        Evaluation.success("aAAaaa1.x", 42),
+        Evaluation.success("aAAaaa2.x", 43)
+      )
     )
   }
 
   test("Should pre-evaluate $outer") {
-    val source =
-      """|package example
-         |
-         |class A {
-         |  val x = 42
-         |  class C
-         |  object C { def life = x }
-         |}
-         |
-         |class B extends A {
-         |  val y = 43
-         |}
-         |
-         |object B extends A {
-         |  val y = 84
-         |}
-         |
-         |object Main {
-         |  def main(args: Array[String]): Unit = {
-         |    val b = new B
-         |    val bc = new b.C
-         |    val bC = b.C
-         |    val Bc = new B.C
-         |    val BC = B.C
-         |    println("ok")
-         |  }
-         |}
-         |""".stripMargin
-    implicit val debuggee = TestingDebuggee.mainClass(source, "example.Main", scalaVersion)
+    implicit val debuggee = outerPreEval
     check(
       Breakpoint(24),
-      Evaluation.success("bc.y", 43),
-      Evaluation.success("bC.y", 43),
-      Evaluation.success("Bc.y", 84),
-      Evaluation.success("BC.y", 84)
+      DebugStepAssert.inParallel(
+        Evaluation.success("bc.y", 43),
+        Evaluation.success("bC.y", 43),
+        Evaluation.success("Bc.y", 84),
+        Evaluation.success("BC.y", 84)
+      )
+    )
+  }
+
+  test("Should evaluate if control flows") {
+    implicit val debuggee = controlFlow
+    check(
+      Breakpoint(7),
+      Evaluation.success("if (true) 1 else 2", 1),
+      Evaluation.success("if (x == 1) 2 else 1", 2),
+      Evaluation.success("if (x == 1) \"a string\" else 1", "a string"),
+      Evaluation.success("test(if(true) 1 else 2)", "int 1"),
+      Evaluation.success("test(if(false) x else t)", "test -1"),
+      Evaluation.success("test(if(true) x else t)", "int 1"),
+      Evaluation.success("(if(true) Test(-1) else x).i", -1),
+      Evaluation.success("(if(false) x else Test(-1)).i", -1),
+      Evaluation.failed("test(if(Test(-1).i == -1) Test(-1) else x)")
     )
   }
 }


### PR DESCRIPTION
Allows to evaluate (and eventually pre-evaluate) flow control at runtime. For instance

```scala
case class Test(i: Int)
def test(t: Test) = s"test ${t.i}"

if (true) 1 else 2                    // res0: Int = 1
(if (true) Test(1) else Test(2)).i    // res1: Int = 1
(if (true) Test(1) else 2).i          // res2: Int = 1 thanks to pre-evaluation
test(if(true) Test(1) else 1)         // res3: String = "test 1"
(if (m()) Test(1) else 2).i          // fails because the `if` cannot be pre-evaluated
```