### PR TITLE
Fix #491: Differentiate getter and method with same name

### DIFF
--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/stacktrace/Scala2Unpickler.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/stacktrace/Scala2Unpickler.scala
@@ -13,7 +13,7 @@ class Scala2Unpickler(
     scalaVersion: ScalaVersion,
     logger: Logger,
     testMode: Boolean
-) extends ScalaUnpickler(scalaVersion) {
+) extends ScalaUnpickler(scalaVersion, testMode) {
   override protected def skipScala(method: jdi.Method): Boolean = {
     if (isLazyInitializer(method)) {
       skipLazyInitializer(method)

--- a/modules/tests/src/main/scala/ch/epfl/scala/debugadapter/testfmk/FakeJdiMethod.scala
+++ b/modules/tests/src/main/scala/ch/epfl/scala/debugadapter/testfmk/FakeJdiMethod.scala
@@ -36,11 +36,11 @@ final case class FakeJdiMethod(
 
   override def compareTo(o: Method): Int = ???
 
-  override def returnTypeName(): String = ???
+  override def returnTypeName(): String = returnType.name
 
   override def argumentTypeNames(): ju.List[String] = ???
 
-  override def argumentTypes(): ju.List[Type] = ???
+  override def argumentTypes(): ju.List[Type] = arguments.asScala.map(_.`type`).asJava
 
   override def isAbstract(): Boolean = ???
 

--- a/modules/unpickler/src/main/scala/ch/epfl/scala/debugadapter/internal/jdi/Method.scala
+++ b/modules/unpickler/src/main/scala/ch/epfl/scala/debugadapter/internal/jdi/Method.scala
@@ -10,8 +10,10 @@ class Method(val obj: Any) extends JavaReflection(obj, "com.sun.jdi.Method"):
     ReferenceType(invokeMethod("declaringType"))
 
   def arguments: Seq[LocalVariable] =
-    invokeMethod[java.util.List[Object]]("arguments").asScala.toSeq
-      .map(LocalVariable.apply(_))
+    invokeMethod[java.util.List[Object]]("arguments").asScala.toSeq.map(LocalVariable.apply(_))
+
+  def argumentTypes: Seq[Type] =
+    invokeMethod[java.util.List[Object]]("argumentTypes").asScala.toSeq.map(Type.apply(_))
 
   def returnType: Option[Type] =
     try Some(Type(invokeMethod("returnType")))
@@ -19,13 +21,12 @@ class Method(val obj: Any) extends JavaReflection(obj, "com.sun.jdi.Method"):
       case e: InvocationTargetException if e.getCause.getClass.getName == "com.sun.jdi.ClassNotLoadedException" =>
         None
 
-  def isExtensionMethod: Boolean =
-    name.endsWith("$extension")
+  def returnTypeName: String = invokeMethod("returnTypeName")
 
-  def isTraitInitializer: Boolean =
-    name == "$init$"
+  def isExtensionMethod: Boolean = name.endsWith("$extension")
 
-  def isClassInitializer: Boolean =
-    name == "<init>"
+  def isTraitInitializer: Boolean = name == "$init$"
+
+  def isClassInitializer: Boolean = name == "<init>"
 
   override def toString: String = invokeMethod("toString")


### PR DESCRIPTION
- Differentiate getter and method with same name
- Catch all exceptions in `ScalaUnpickler`