### PR TITLE
Skip private accessors

### DIFF
--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/stacktrace/ScalaUnpickler.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/stacktrace/ScalaUnpickler.scala
@@ -24,12 +24,12 @@ abstract class ScalaUnpickler(scalaVersion: ScalaVersion, testMode: Boolean) ext
   override def shouldSkipOver(method: Method): Boolean = {
     if (method.isBridge) true
     else if (isDynamicClass(method.declaringType)) true
-    // else if (scalaVersion.isScala2 && isPackagePrivateAccessor(method)) true
     else if (isJava(method)) false
     else if (isConstructor(method)) false
     else if (isStaticConstructor(method)) false
     else if (isAdaptedMethod(method)) true
     else if (isAnonFunction(method)) false
+    else if (scalaVersion.isScala2 && isPrivateAccessor(method)) true
     else if (isLiftedMethod(method)) !isLazyInitializer(method) && isLazyGetter(method)
     else if (isAnonClass(method.declaringType)) false
     // TODO in Scala 3 we should be able to find the symbol of a local class using TASTy Query
@@ -145,11 +145,8 @@ abstract class ScalaUnpickler(scalaVersion: ScalaVersion, testMode: Boolean) ext
   private def skipTraitInitializer(method: Method): Boolean =
     method.bytecodes.toSeq == Seq(ByteCodes.RETURN)
 
-  private def isPackagePrivateAccessor(method: Method): Boolean = {
-    val name = method.name
-    val regex = """\$access\$\d+""".r
-    regex.findFirstIn(name.take(name.indexOf('('))).isDefined
-  }
+  private def isPrivateAccessor(method: Method): Boolean =
+    method.name.matches(""".+\$access\$\d+""")
 }
 
 object ScalaUnpickler {

--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/stacktrace/ScalaUnpickler.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/stacktrace/ScalaUnpickler.scala
@@ -24,6 +24,7 @@ abstract class ScalaUnpickler(scalaVersion: ScalaVersion, testMode: Boolean) ext
   override def shouldSkipOver(method: Method): Boolean = {
     if (method.isBridge) true
     else if (isDynamicClass(method.declaringType)) true
+    // else if (scalaVersion.isScala2 && isPackagePrivateAccessor(method)) true
     else if (isJava(method)) false
     else if (isConstructor(method)) false
     else if (isStaticConstructor(method)) false
@@ -143,6 +144,12 @@ abstract class ScalaUnpickler(scalaVersion: ScalaVersion, testMode: Boolean) ext
 
   private def skipTraitInitializer(method: Method): Boolean =
     method.bytecodes.toSeq == Seq(ByteCodes.RETURN)
+
+  private def isPackagePrivateAccessor(method: Method): Boolean = {
+    val name = method.name
+    val regex = """\$access\$\d+""".r
+    regex.findFirstIn(name.take(name.indexOf('('))).isDefined
+  }
 }
 
 object ScalaUnpickler {

--- a/modules/tests/src/main/scala/ch/epfl/scala/debugadapter/testfmk/TestingDebugClient.scala
+++ b/modules/tests/src/main/scala/ch/epfl/scala/debugadapter/testfmk/TestingDebugClient.scala
@@ -332,7 +332,7 @@ class AbstractDebugClient(
       timeout: Duration
   )(f: Messages.Event => Boolean): Messages.Event = {
     Iterator
-      .continually(events.poll(timeout.toMillis, TimeUnit.DAYS))
+      .continually(events.poll(timeout.toMillis, TimeUnit.MILLISECONDS))
       .map(e => if (e == null) throw new TimeoutException() else e)
       .filter(f)
       .next()

--- a/modules/tests/src/main/scala/ch/epfl/scala/debugadapter/testfmk/TestingDebugClient.scala
+++ b/modules/tests/src/main/scala/ch/epfl/scala/debugadapter/testfmk/TestingDebugClient.scala
@@ -332,7 +332,7 @@ class AbstractDebugClient(
       timeout: Duration
   )(f: Messages.Event => Boolean): Messages.Event = {
     Iterator
-      .continually(events.poll(timeout.toMillis, TimeUnit.MILLISECONDS))
+      .continually(events.poll(timeout.toMillis, TimeUnit.DAYS))
       .map(e => if (e == null) throw new TimeoutException() else e)
       .filter(f)
       .next()

--- a/modules/tests/src/test/scala/ch/epfl/scala/debugadapter/StepFilterTests.scala
+++ b/modules/tests/src/test/scala/ch/epfl/scala/debugadapter/StepFilterTests.scala
@@ -3,6 +3,7 @@ package ch.epfl.scala.debugadapter
 import ch.epfl.scala.debugadapter.testfmk.*
 
 class Scala3StepFilterTests extends StepFilterTests(ScalaVersion.`3.1+`) {
+
   test("step into method with @targetName") {
     val source =
       """|package example
@@ -25,25 +26,6 @@ class Scala3StepFilterTests extends StepFilterTests(ScalaVersion.`3.1+`) {
 
 class Scala212StepFilterTests extends StepFilterTests(ScalaVersion.`2.12`)
 class Scala213StepFilterTests extends StepFilterTests(ScalaVersion.`2.13`) {
-  test("skip package-private accessors".only) {
-    val source =
-      """|package example
-         |
-         |case class Test[A](private[example] var test: A)
-         |
-         |object Main {
-         |  def main(args: Array[String]): Unit = {
-         |    val test = Test(42)
-         |    println(test.test)
-         |  }
-         |}
-         |""".stripMargin
-    implicit val debuggee: TestingDebuggee = TestingDebuggee.mainClass(source, "example.Main", scalaVersion)
-    check(
-      Breakpoint(8),
-      Evaluation.success("test.test", 42)
-    )
-  }
 
   test("should match all kinds of Scala 2 types (not valid in Scala 3)") {
     val source =
@@ -72,6 +54,8 @@ class Scala213StepFilterTests extends StepFilterTests(ScalaVersion.`2.13`) {
 }
 
 abstract class StepFilterTests(protected val scalaVersion: ScalaVersion) extends DebugTestSuite {
+  private val printlnMethod =
+    if (scalaVersion.isScala3) "Predef.println(x: Any): Unit" else "Predef$.println(Object): void"
   test("should not step into mixin forwarder") {
     val source =
       """|package example
@@ -430,19 +414,19 @@ abstract class StepFilterTests(protected val scalaVersion: ScalaVersion) extends
         StepIn.method("String.toString(): String"),
         StepIn.line(4),
         StepIn.line(9),
-        StepIn.method(if (isScala3) "Predef.println(x: Any): Unit" else "Predef$.println(Object)"),
+        StepIn.method(printlnMethod),
         Breakpoint(10),
         StepIn.line(4),
         StepOut.line(10),
-        StepIn.method(if (isScala3) "Predef.println(x: Any): Unit" else "Predef$.println(Object)"),
+        StepIn.method(printlnMethod),
         Breakpoint(11),
         StepIn.line(18),
         StepIn.method("String.toString(): String"),
         StepIn.line(18),
         StepIn.line(11),
-        StepIn.method(if (isScala3) "Predef.println(x: Any): Unit" else "Predef$.println(Object)"),
+        StepIn.method(printlnMethod),
         Breakpoint(12),
-        StepIn.method(if (isScala3) "Predef.println(x: Any): Unit" else "Predef$.println(Object)")
+        StepIn.method(printlnMethod)
       )
     } else if (isScala3) {
       check(
@@ -455,20 +439,20 @@ abstract class StepFilterTests(protected val scalaVersion: ScalaVersion) extends
         StepIn.line(6),
         StepIn.line(5),
         StepOut.line(9),
-        StepIn.method(if (isScala3) "Predef.println(x: Any): Unit" else "Predef$.println(Object)"),
+        StepIn.method(printlnMethod),
         Breakpoint(10),
         StepIn.line(4),
         StepIn.line(6),
         StepIn.line(4),
         StepIn.line(6),
         StepOut.line(10),
-        StepIn.method(if (isScala3) "Predef.println(x: Any): Unit" else "Predef$.println(Object)"),
+        StepIn.method(printlnMethod),
         Breakpoint(11),
         StepIn.line(18),
         StepOut.line(11),
-        StepIn.method(if (isScala3) "Predef.println(x: Any): Unit" else "Predef$.println(Object)"),
+        StepIn.method(printlnMethod),
         Breakpoint(12),
-        StepIn.method(if (isScala3) "Predef.println(x: Any): Unit" else "Predef$.println(Object)")
+        StepIn.method(printlnMethod)
       )
     } else {
       check(
@@ -476,15 +460,15 @@ abstract class StepFilterTests(protected val scalaVersion: ScalaVersion) extends
         StepIn.line(4),
         StepIn.line(5),
         StepOut.line(9),
-        StepIn.method(if (isScala3) "Predef.println(x: Any): Unit" else "Predef$.println(Object): void"),
+        StepIn.method(printlnMethod),
         Breakpoint(10),
-        StepIn.method(if (isScala3) "Predef.println(x: Any): Unit" else "Predef$.println(Object): void"),
+        StepIn.method(printlnMethod),
         Breakpoint(11),
         StepIn.line(18),
         StepOut.line(11),
-        StepIn.method(if (isScala3) "Predef.println(x: Any): Unit" else "Predef$.println(Object): void"),
+        StepIn.method(printlnMethod),
         Breakpoint(12),
-        StepIn.method(if (isScala3) "Predef.println(x: Any): Unit" else "Predef$.println(Object): void")
+        StepIn.method(printlnMethod)
       )
     }
   }
@@ -1022,14 +1006,14 @@ abstract class StepFilterTests(protected val scalaVersion: ScalaVersion) extends
       Breakpoint(8),
       StepIn.method(if (isScala3) "A.<init>(as: String*): Unit" else "A.<init>(Seq): void"),
       Breakpoint(9),
-      StepIn.method(if (isScala3) "Predef.println(x: Any): Unit" else "Predef$.println(Object): void"),
+      StepIn.method(printlnMethod),
       Breakpoint(10),
       StepIn.method(
         if (isScala3) "StringContext.<init>(parts: String*): Unit"
         else "StringContext.<init>(Seq): void"
       ),
       Breakpoint(11),
-      StepIn.method(if (isScala3) "Predef.println(x: Any): Unit" else "Predef$.println(Object): void")
+      StepIn.method(printlnMethod)
     )
   }
 
@@ -1190,5 +1174,23 @@ abstract class StepFilterTests(protected val scalaVersion: ScalaVersion) extends
          |""".stripMargin
     implicit val debuggee: TestingDebuggee = TestingDebuggee.mainClass(source, "example.Main", scalaVersion)
     check(Breakpoint(8), Evaluation.success("foo", 42))
+  }
+
+  test("skip private accessor") {
+    val source =
+      """|package example
+         |
+         |final case class A(private val x: String)
+         |
+         |object Main {
+         |  def main(args: Array[String]): Unit = {
+         |    val a1 = new A("a1")
+         |    val a2 = new A("a2")
+         |    a1 == a2
+         |  }
+         |}
+         |""".stripMargin
+    implicit val debuggee: TestingDebuggee = TestingDebuggee.mainClass(source, "example.Main", scalaVersion)
+    check(Breakpoint(9), StepIn.method("String.equals(Object): boolean"))
   }
 }

--- a/modules/unpickler/src/main/scala/ch/epfl/scala/debugadapter/internal/stacktrace/Scala3Unpickler.scala
+++ b/modules/unpickler/src/main/scala/ch/epfl/scala/debugadapter/internal/stacktrace/Scala3Unpickler.scala
@@ -352,15 +352,6 @@ class Scala3Unpickler(
     rec(scalaType.toString, javaType.name)
 
   private def skip(symbol: TermSymbol): Boolean =
-    // TODO : remove in next TASTy query version
-    def isScala2GetterWorkaround: Boolean =
-      symbol.sourceLanguage == SourceLanguage.Scala2
-        && symbol.declaredType.isInstanceOf[Type]
-        && symbol.owner.isClass
-        && symbol.owner.asClass.getDecl(termName(symbol.name.toString + " ")).isDefined
-
     val isNonLazyGetterOrSetter =
-      (!symbol.isMethod || isScala2GetterWorkaround || symbol.isSetter) && symbol.kind != TermSymbolKind.LazyVal
-    def isNonPublicAccessor = !symbol.isPublic && symbol.isParamAccessor
-    // def isGivenValGetter = (symbol.isGivenOrUsing || symbol.isImplicit) && symbol.kind == TermSymbolKind.Val
-    isNonLazyGetterOrSetter || symbol.isSynthetic || isNonPublicAccessor // || isGivenValGetter
+      (!symbol.isMethod || symbol.isSetter) && symbol.kind != TermSymbolKind.LazyVal
+    isNonLazyGetterOrSetter || symbol.isSynthetic

--- a/modules/unpickler/src/main/scala/ch/epfl/scala/debugadapter/internal/stacktrace/Scala3Unpickler.scala
+++ b/modules/unpickler/src/main/scala/ch/epfl/scala/debugadapter/internal/stacktrace/Scala3Unpickler.scala
@@ -361,4 +361,6 @@ class Scala3Unpickler(
 
     val isNonLazyGetterOrSetter =
       (!symbol.isMethod || isScala2GetterWorkaround || symbol.isSetter) && symbol.kind != TermSymbolKind.LazyVal
-    isNonLazyGetterOrSetter || symbol.isSynthetic
+    def isNonPublicAccessor = !symbol.isPublic && symbol.isParamAccessor
+    // def isGivenValGetter = (symbol.isGivenOrUsing || symbol.isImplicit) && symbol.kind == TermSymbolKind.Val
+    isNonLazyGetterOrSetter || symbol.isSynthetic || isNonPublicAccessor // || isGivenValGetter


### PR DESCRIPTION
Fixes #332 
Only works for Scala 2 as there are no methods named `xxx$access$\d+` in Scala 3
Also remvoved `final` attribute from `FakeJdiMethod` and `FakeJdiType` to be able to create anon classes to solve `NotImplementedError` at call site