### PR TITLE
Make ClassEntryLookup accommodate case-insensitive lookups where appropriate

### DIFF
--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/ClassEntryLookUp.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/ClassEntryLookUp.scala
@@ -15,7 +15,7 @@ import ch.epfl.scala.debugadapter.internal.scalasig.Decompiler
 import ch.epfl.scala.debugadapter.internal.ScalaExtension.*
 import scala.util.Try
 
-private case class SourceLine(uri: URI, lineNumber: Int)
+private case class SourceLineKey(sourceFileKey: SourceFileKey, lineNumber: Int)
 
 private[internal] case class ClassFile(
     fullyQualifiedName: String,
@@ -35,16 +35,16 @@ private[internal] case class ClassFile(
 private class ClassEntryLookUp(
     val entry: ClassEntry,
     fqcnToClassFile: Map[String, ClassFile],
-    sourceUriToSourceFile: Map[URI, SourceFile],
-    sourceUriToClassFiles: Map[URI, Seq[ClassFile]],
+    sourceUriToSourceFile: Map[SourceFileKey, SourceFile],
+    sourceUriToClassFiles: Map[SourceFileKey, Seq[ClassFile]],
     classNameToSourceFile: Map[String, SourceFile],
     missingSourceFileClassFiles: Seq[ClassFile],
     val orphanClassFiles: Seq[ClassFile],
     logger: Logger
 ) {
-  private val cachedSourceLines = mutable.Map[SourceLine, Seq[ClassFile]]()
+  private val cachedSourceLines = mutable.Map[SourceLineKey, Seq[ClassFile]]()
 
-  def sources: Iterable[URI] = sourceUriToSourceFile.keys
+  def sources: Iterable[SourceFileKey] = sourceUriToSourceFile.keys
   def fullyQualifiedNames: Iterable[String] = {
     classNameToSourceFile.keys ++
       orphanClassFiles.map(_.fullyQualifiedName) ++
@@ -55,18 +55,19 @@ private class ClassEntryLookUp(
     fullyQualifiedNames.groupBy[String](NameTransformer.scalaClassName)
 
   def getFullyQualifiedClassName(
-      sourceUri: URI,
+      sourceKey: SourceFileKey,
       lineNumber: Int
   ): Option[String] = {
-    val line = SourceLine(sourceUri, lineNumber)
+    val line = SourceLineKey(sourceKey, lineNumber)
 
     if (!cachedSourceLines.contains(line)) {
       // read and cache line numbers from class files
-      sourceUriToClassFiles(sourceUri)
+      sourceUriToClassFiles
+        .getOrElse(sourceKey, Nil)
         .groupBy(_.classSystem)
         .foreach { case (classSystem, classFiles) =>
           classSystem
-            .within((_, root) => loadLineNumbers(root, classFiles, sourceUri))
+            .within((_, root) => loadLineNumbers(root, classFiles, sourceKey))
             .warnFailure(logger, s"Cannot load line numbers in ${classSystem.name}")
         }
     }
@@ -83,7 +84,7 @@ private class ClassEntryLookUp(
   private def loadLineNumbers(
       root: Path,
       classFiles: Seq[ClassFile],
-      sourceUri: URI
+      sourceKey: SourceFileKey
   ): Unit = {
     for (classFile <- classFiles) {
       val path = root.resolve(classFile.relativePath)
@@ -111,7 +112,7 @@ private class ClassEntryLookUp(
         reader.accept(visitor, 0)
 
         for (n <- lineNumbers) {
-          val line = SourceLine(sourceUri, n)
+          val line = SourceLineKey(sourceKey, n)
           cachedSourceLines.update(
             line,
             cachedSourceLines.getOrElse(line, Seq.empty) :+ classFile
@@ -122,16 +123,16 @@ private class ClassEntryLookUp(
   }
 
   def getSourceContent(sourceUri: URI): Option[String] =
-    sourceUriToSourceFile.get(sourceUri).flatMap(readSourceContent(_, logger))
+    sourceUriToSourceFile.get(SourceFileKey(sourceUri)).flatMap(readSourceContent(_, logger))
 
-  def getSourceFile(fqcn: String): Option[URI] =
+  def getSourceFileURI(fqcn: String): Option[URI] =
     classNameToSourceFile.get(fqcn).map(_.uri)
 
   def getSourceContentFromClassName(fqcn: String): Option[String] =
-    getSourceFile(fqcn).flatMap(getSourceContent)
+    getSourceFileURI(fqcn).flatMap(getSourceContent)
 
   def getClassFiles(sourceUri: URI): Seq[ClassFile] =
-    sourceUriToClassFiles.get(sourceUri).getOrElse(Seq.empty)
+    sourceUriToClassFiles.get(SourceFileKey(sourceUri)).getOrElse(Seq.empty)
 
   def getClassFile(fqcn: String): Option[ClassFile] =
     fqcnToClassFile.get(fqcn)
@@ -146,7 +147,7 @@ private class ClassEntryLookUp(
     def fromSource = {
       val scalaSigs =
         for {
-          sourceFile <- getSourceFile(fqcn).toSeq
+          sourceFile <- getSourceFileURI(fqcn).toSeq
           if sourceFile.toString.endsWith(".scala")
           classFile <- getClassFiles(sourceFile)
           if fqcn.startsWith(classFile.fullyQualifiedName + "$")
@@ -183,11 +184,11 @@ private object ClassEntryLookUp {
       classFiles.map(c => (c.fullyQualifiedName, c)).toMap
 
     val sourceFileToRoot = sourceLookUps.flatMap(l => l.sourceFiles.map(f => (f -> l.root))).toMap
-    val sourceUriToSourceFile = sourceLookUps.flatMap(_.sourceFiles).map(f => (f.uri, f)).toMap
+    val sourceUriToSourceFile = sourceLookUps.flatMap(_.sourceFiles).map(f => (SourceFileKey(f.uri), f)).toMap
     val sourceNameToSourceFile = sourceLookUps.flatMap(_.sourceFiles).groupBy(f => f.fileName)
 
     val classNameToSourceFile = mutable.Map[String, SourceFile]()
-    val sourceUriToClassFiles = mutable.Map[URI, Seq[ClassFile]]()
+    val sourceUriToClassFiles = mutable.Map[SourceFileKey, Seq[ClassFile]]()
     val orphanClassFiles = mutable.Buffer[ClassFile]()
     val missingSourceFileClassFiles = mutable.Buffer[ClassFile]()
 
@@ -195,9 +196,9 @@ private object ClassEntryLookUp {
       def recordSourceFile(sourceFile: SourceFile): Unit = {
         classNameToSourceFile.put(classFile.fullyQualifiedName, sourceFile)
         sourceUriToClassFiles.update(
-          sourceFile.uri,
+          SourceFileKey(sourceFile.uri),
           sourceUriToClassFiles.getOrElse(
-            sourceFile.uri,
+            SourceFileKey(sourceFile.uri),
             Seq.empty
           ) :+ classFile
         )

--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/SourceEntryLookUp.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/SourceEntryLookUp.scala
@@ -15,42 +15,6 @@ import ch.epfl.scala.debugadapter.internal.ScalaExtension.*
 import scala.util.control.NonFatal
 import scala.util.Properties
 
-/*SourceFileKey abstracts the URI string used for lookups so that we can control how casing is handled in different OS filesystems, i.e. allowing case-insensitive file lookups on windows and mac, while keeping case-sensitive on linux.
- * Note the URI scheme portion (i.e. "file:") is always case-insensitive, which is currently handled by the URI class.
- */
-case class SourceFileKey private (private val uri: URI)
-
-object SourceFileKey {
-
-  val isCaseSensitiveFileSystem = Properties.isWin || Properties.isMac
-
-  def apply(uri: URI): SourceFileKey = {
-
-    val conditionedUri: URI =
-      if (isCaseSensitiveFileSystem) {
-        uri.getScheme.toLowerCase match {
-          case "file" => URI.create(uri.toString().toUpperCase())
-          case "jar" =>
-            // The contents of jars are case-sensitive no matter what the filesystem is.
-
-            val tokens = uri.toString().split("!/", 2).toSeq
-
-            val firstPart = if (tokens.size >= 1) tokens(0).toUpperCase() else ""
-            val secondPart = if (tokens.size >= 2) tokens(1) else ""
-
-            URI.create(s"$firstPart!/$secondPart")
-          case _ => uri // For now, just keep the uri as is if unsupported.
-        }
-      } else {
-        uri
-      }
-
-    new SourceFileKey(conditionedUri)
-  }
-}
-
-///////////////////////////////////////////////////////////////
-
 private case class SourceFile(
     entry: SourceEntry,
     relativePath: String,

--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/SourceEntryLookUp.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/SourceEntryLookUp.scala
@@ -15,44 +15,41 @@ import ch.epfl.scala.debugadapter.internal.ScalaExtension.*
 import scala.util.control.NonFatal
 import scala.util.Properties
 
-
 /*SourceFileKey abstracts the URI string used for lookups so that we can control how casing is handled in different OS filesystems, i.e. allowing case-insensitive file lookups on windows and mac, while keeping case-sensitive on linux.
-* Note the URI scheme portion (i.e. "file:") is always case-insensitive, which is currently handled by the URI class.
-*/
-case class SourceFileKey private(private val uri:URI)
+ * Note the URI scheme portion (i.e. "file:") is always case-insensitive, which is currently handled by the URI class.
+ */
+case class SourceFileKey private (private val uri: URI)
 
-object SourceFileKey{
+object SourceFileKey {
 
   val isCaseSensitiveFileSystem = Properties.isWin || Properties.isMac
 
-  def apply(uri:URI): SourceFileKey = {
+  def apply(uri: URI): SourceFileKey = {
 
-    val conditionedUri:URI = 
-      if(isCaseSensitiveFileSystem){
-        uri.getScheme.toLowerCase match{
-          case "file"  => URI.create(uri.toString().toUpperCase())
-          case "jar" => {
-            //The contents of jars are case-sensitive no matter what the filesystem is.
-            
+    val conditionedUri: URI =
+      if (isCaseSensitiveFileSystem) {
+        uri.getScheme.toLowerCase match {
+          case "file" => URI.create(uri.toString().toUpperCase())
+          case "jar" =>
+            // The contents of jars are case-sensitive no matter what the filesystem is.
+
             val tokens = uri.toString().split("!/", 2).toSeq
-            
-            val firstPart = if(tokens.size >= 1) tokens(0).toUpperCase() else ""
-            val secondPart = if(tokens.size >= 2) tokens(1) else ""
-                                    
-            URI.create(s"${firstPart}!/${secondPart}")
-          }
-          case _ => uri //For now, just keep the uri as is if unsupported.
+
+            val firstPart = if (tokens.size >= 1) tokens(0).toUpperCase() else ""
+            val secondPart = if (tokens.size >= 2) tokens(1) else ""
+
+            URI.create(s"$firstPart!/$secondPart")
+          case _ => uri // For now, just keep the uri as is if unsupported.
         }
-      }else{
+      } else {
         uri
       }
 
     new SourceFileKey(conditionedUri)
   }
- }
+}
 
- ///////////////////////////////////////////////////////////////
-
+///////////////////////////////////////////////////////////////
 
 private case class SourceFile(
     entry: SourceEntry,

--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/SourceLookUpProvider.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/SourceLookUpProvider.scala
@@ -9,7 +9,7 @@ import scala.collection.parallel.immutable.ParVector
 
 private[debugadapter] final class SourceLookUpProvider(
     private[internal] var classPathEntries: Seq[ClassEntryLookUp],
-    private var sourceUriToClassPathEntry: Map[URI, ClassEntryLookUp],
+    private var sourceUriToClassPathEntry: Map[SourceFileKey, ClassEntryLookUp],
     private var fqcnToClassPathEntry: Map[String, ClassEntryLookUp],
     logger: Logger
 ) extends ISourceLookUpProvider {
@@ -18,13 +18,13 @@ private[debugadapter] final class SourceLookUpProvider(
   override def supportsRealtimeBreakpointVerification(): Boolean = true
 
   override def getSourceFileURI(fqcn: String, path: String): String = {
-    getSourceFile(fqcn).map(_.toString).orNull
+    getSourceFileByClassname(fqcn).map(_.toString).orNull
   }
 
   override def getSourceContents(uri: String): String = {
     val sourceUri = URI.create(uri)
     sourceUriToClassPathEntry
-      .get(sourceUri)
+      .get(SourceFileKey(sourceUri))
       .flatMap(_.getSourceContent(sourceUri))
       .orNull
   }
@@ -35,15 +35,18 @@ private[debugadapter] final class SourceLookUpProvider(
       columns: Array[Int]
   ): Array[String] = {
     val uri = URI.create(uriRepr)
-    uri.getScheme match {
+
+    uri.getScheme.toLowerCase match {
       case "dap-fqcn" =>
         val resolvedName = uri.getSchemeSpecificPart
         lines.map(_ => resolvedName)
       case _ =>
-        sourceUriToClassPathEntry.get(uri) match {
+        val key = SourceFileKey(uri);
+
+        sourceUriToClassPathEntry.get(key) match {
           case None => lines.map(_ => null)
           case Some(entry) =>
-            lines.map(line => entry.getFullyQualifiedClassName(uri, line).orNull)
+            lines.map(line => entry.getFullyQualifiedClassName(key, line).orNull)
         }
     }
   }
@@ -74,10 +77,10 @@ private[debugadapter] final class SourceLookUpProvider(
     } yield scalaSig
   }
 
-  private def getSourceFile(className: String): Option[URI] = {
+  private def getSourceFileByClassname(className: String): Option[URI] = {
     fqcnToClassPathEntry
       .get(className)
-      .flatMap(_.getSourceFile(className))
+      .flatMap(_.getSourceFileURI(className))
   }
 
   def reload(classesToReplace: Seq[String]): Unit = {

--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/SourceLookUpProvider.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/SourceLookUpProvider.scala
@@ -36,13 +36,12 @@ private[debugadapter] final class SourceLookUpProvider(
   ): Array[String] = {
     val uri = URI.create(uriRepr)
 
-    uri.getScheme.toLowerCase match {
+    uri.getScheme match {
       case "dap-fqcn" =>
         val resolvedName = uri.getSchemeSpecificPart
         lines.map(_ => resolvedName)
       case _ =>
         val key = SourceFileKey(uri);
-
         sourceUriToClassPathEntry.get(key) match {
           case None => lines.map(_ => null)
           case Some(entry) =>

--- a/modules/tests/src/test/scala/ch/epfl/scala/debugadapter/internal/ClassEntryLookUpSpec.scala
+++ b/modules/tests/src/test/scala/ch/epfl/scala/debugadapter/internal/ClassEntryLookUpSpec.scala
@@ -8,13 +8,11 @@ import ch.epfl.scala.debugadapter.SourceJar
 import java.net.URI
 import ch.epfl.scala.debugadapter.testfmk.NoopLogger
 import munit.FunSuite
-import java.nio.file.Path
 import scala.util.Properties
-
+import java.nio.file.Paths
 
 class ClassEntryLookUpSpec extends FunSuite {
   val isFilesystemCaseInsensitive = Properties.isWin || Properties.isMac
-
 
   test("should map source files to class names and backward, in project") {
     val debuggee = TestingDebuggee.scalaBreakpointTest(ScalaVersion.`2.12`)
@@ -77,7 +75,7 @@ class ClassEntryLookUpSpec extends FunSuite {
       jar
     }.get
     val sourceFile = URI.create(s"jar:${sourceJar.toUri}!/cats/instances/list.scala")
- 
+
     val sourceFileContent = lookUp.getSourceContent(sourceFile)
     val contentSize = sourceFileContent.fold(0)(_.size)
     assert(contentSize == 8717)
@@ -93,26 +91,27 @@ class ClassEntryLookUpSpec extends FunSuite {
     assert(lookUp.sources.isEmpty)
   }
 
-    test("project class lookups should accomodate case-sensitivity of the OS filesystem") {
+  test("project class lookups should accomodate case-sensitivity of the OS filesystem") {
     val debuggee = TestingDebuggee.scalaBreakpointTest(ScalaVersion.`2.12`)
-    val lookUp = ClassEntryLookUp(debuggee.mainModule, NoopLogger)    
-    
+    val lookUp = ClassEntryLookUp(debuggee.mainModule, NoopLogger)
+
     val sourceFilePath = debuggee.sourceFiles.head;
 
-    //Change case of file. 
+    // Change case of file.
     val sourceFilePathString = sourceFilePath.toString()
-    assert(sourceFilePathString.contains("scala-debug-adapter")) //precondition for this test.
-       
-    //Change some casing of the path uri
-    val lookupKey = SourceFileKey(Path.of(sourceFilePathString.replace("scala-debug-adapter", "SCALA-deBug-Adapter")).toUri)
-           
+    assert(sourceFilePathString.contains("scala-debug-adapter")) // precondition for this test.
+
+    // Change some casing of the path uri
+    val lookupKey =
+      SourceFileKey(Paths.get(sourceFilePathString.replace("scala-debug-adapter", "SCALA-deBug-Adapter")).toUri)
+
     val expectedClassName = "example.Main$Hello$InnerHello$1"
 
-    //Note: The expected result is different based on the OS this test is running on.    
+    // Note: The expected result is different based on the OS this test is running on.
     val className = lookUp.getFullyQualifiedClassName(lookupKey, 14)
-    assertEquals(isFilesystemCaseInsensitive, className.contains(expectedClassName))   
+    assertEquals(isFilesystemCaseInsensitive, className.contains(expectedClassName))
   }
-  
+
   test("dependency jar source lookups should accomodate case-sensitivity of the OS filesystem") {
     val catsCore = TestingResolver.fetchOnly("org.typelevel", "cats-core_3", "2.6.1")
     val lookUp = ClassEntryLookUp(catsCore, NoopLogger)
@@ -122,23 +121,23 @@ class ClassEntryLookUpSpec extends FunSuite {
     }.get
 
     val sourceJarPathString = sourceJar.toString()
-    assert(sourceJarPathString.contains("cats-core")) //precondition for this test
-          
+    assert(sourceJarPathString.contains("cats-core")) // precondition for this test
+
     val expectedClassName = "cats.instances.ListInstances$$anon$1"
 
-    {            
-      val moddedSourceJarPath = Path.of(sourceJarPathString.replace("cats-core", "Cats-CoRe"));
-      val moddedSourceJarUri = URI.create(s"jar:${moddedSourceJarPath.toUri()}!/cats/instances/list.scala")        
-    
-      //Note: The expected results are different based on the OS this test is running on. 
+    {
+      val moddedSourceJarPath = Paths.get(sourceJarPathString.replace("cats-core", "Cats-CoRe"));
+      val moddedSourceJarUri = URI.create(s"jar:${moddedSourceJarPath.toUri()}!/cats/instances/list.scala")
+
+      // Note: The expected results are different based on the OS this test is running on.
       val className = lookUp.getFullyQualifiedClassName(SourceFileKey(moddedSourceJarUri), 28)
-      assertEquals(isFilesystemCaseInsensitive, className.contains(expectedClassName))      
+      assertEquals(isFilesystemCaseInsensitive, className.contains(expectedClassName))
     }
 
-    { 
+    {
       val moddedSourceJarUri = URI.create(s"jar:${sourceJar.toUri()}!/caTs/Instances/list.scala")
-      
-      //The contents of Jar file is case-sensitive regardless of OS filesystem
+
+      // The contents of Jar file is case-sensitive regardless of OS filesystem
       val className = lookUp.getFullyQualifiedClassName(SourceFileKey(moddedSourceJarUri), 28)
       assert(className.isEmpty)
     }

--- a/modules/tests/src/test/scala/ch/epfl/scala/debugadapter/internal/MetalsClassBreakpointSuite.scala
+++ b/modules/tests/src/test/scala/ch/epfl/scala/debugadapter/internal/MetalsClassBreakpointSuite.scala
@@ -175,10 +175,10 @@ class MetalsClassBreakpointSuite extends FunSuite {
     val debuggee = TestingDebuggee.mainClass(source, "Main", scalaVersion)
     val lookUp = ClassEntryLookUp(debuggee.mainModule, NoopLogger)
 
-    val sourceFile = debuggee.sourceFiles.head.toUri
+    val sourceFileKey = SourceFileKey(debuggee.sourceFiles.head.toUri)
 
     val className =
-      lookUp.getFullyQualifiedClassName(sourceFile, lineNumber)
+      lookUp.getFullyQualifiedClassName(sourceFileKey, lineNumber)
     assert(className.contains(expectedClassName))
   }
 }


### PR DESCRIPTION
This PR changes ClassEntryLookup so that it can lookup sourceFile URIs in a case-insensitive on case-insensitive file-systems.

For instance, on Windows, "file:///C/MyProject/A.scala" should map to the same objects as "file:///C:/myProject/A.scala". 

This PR should fix:
* This should fix scalameta/Metals issue [#3747](https://github.com/scalameta/metals/issues/3747)
* #614 

Solution Notes: 
- The maps in ClassEntryLookup now are keyed with a new SourceFileKey class that abstracts the URI and how it is represented.
- For Windows/Mac: 
  - For “file” scheme URIs, the comparison of the file part of the URI is compared in a case-insensitive way.
  - For “jar” scheme URIs, the comparison of the file part of the URI is compared in a case-insensitive way, but the jar-contents part is compared in case-sensitive way per jar rules. 
  - Other schemes are left case-sensitive
- Linux:
  - Remains case-sensitive

Since this is causing issues in Metals and Bloop, this PR should probably get into a release branch when approved. 