### PR TITLE
Fix parsing launch arguments

### DIFF
--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/DebugSession.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/DebugSession.scala
@@ -153,7 +153,7 @@ private[debugadapter] final class DebugSession private (
         val command = Command.parse(request.command)
         // the launch args sent by Metals do not conform to the LaunchArgument of java-debug
         // here we parse to PartialLaunchArguments which only contains noDebug
-        val launchArgs = JsonUtils.fromJson(request.arguments, classOf[PartialLaunchArguments])
+        val launchArgs = JsonUtils.fromJson(request.arguments, classOf[ScalaLaunchArguments])
         val tools =
           if (launchArgs.noDebug) DebugTools.none(logger)
           else DebugTools(debuggee, resolver, logger)

--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/ScalaLaunchArguments.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/ScalaLaunchArguments.scala
@@ -1,8 +1,8 @@
 package ch.epfl.scala.debugadapter.internal;
 
-import com.microsoft.java.debug.core.protocol.Requests.LaunchArguments
 import ch.epfl.scala.debugadapter.StepFiltersConfig
 
-case class PartialLaunchArguments(
+case class ScalaLaunchArguments(
+    noDebug: Boolean,
     scalaStepFilters: StepFiltersConfig
-) extends LaunchArguments
+)

--- a/modules/tests/src/main/scala/ch/epfl/scala/debugadapter/testfmk/TestingDebugClient.scala
+++ b/modules/tests/src/main/scala/ch/epfl/scala/debugadapter/testfmk/TestingDebugClient.scala
@@ -23,7 +23,7 @@ import ch.epfl.scala.debugadapter.Logger
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.Future
 import scala.concurrent.Await
-import ch.epfl.scala.debugadapter.internal.PartialLaunchArguments
+import ch.epfl.scala.debugadapter.internal.ScalaLaunchArguments
 import ch.epfl.scala.debugadapter.StepFiltersConfig
 
 class TestingDebugClient(socket: Socket, logger: Logger)(implicit
@@ -53,7 +53,7 @@ class TestingDebugClient(socket: Socket, logger: Logger)(implicit
       timeout: Duration = defaultTimeout(16.seconds),
       stepFilters: StepFiltersConfig = null
   ): Messages.Response = {
-    val request = createRequest(Command.LAUNCH, new PartialLaunchArguments(stepFilters))
+    val request = createRequest(Command.LAUNCH, new ScalaLaunchArguments(noDebug = false, stepFilters))
 
     Await.result(sendRequest(request), timeout)
   }


### PR DESCRIPTION
The current version of the scala-debug-adapter fail at parsing the launch arguments coming from Metals.