### PR TITLE
Fix #628: remove `indent` and `-rewrite` options when evaluating expression

### DIFF
--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/DebugTools.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/DebugTools.scala
@@ -120,7 +120,7 @@ object DebugTools {
     debuggee.managedEntries.flatMap(loadExpressionCompiler).toMap
   }
 
-  private val optionsToRemove = Set("-Xfatal-warnings", "-Werror")
+  private val optionsToRemove = Set("-Xfatal-warnings", "-Werror", "-indent", "-rewrite")
 
   private def prepareOptions(options: Seq[String], toAdd: Seq[String]) = {
     val withoutRemoved = options.filter(o => !optionsToRemove.contains(o))

--- a/modules/tests/src/main/scala/ch/epfl/scala/debugadapter/testfmk/DebugTestSuite.scala
+++ b/modules/tests/src/main/scala/ch/epfl/scala/debugadapter/testfmk/DebugTestSuite.scala
@@ -229,8 +229,8 @@ trait DebugTest extends CommonUtils {
       continueIfPaused()
       // This is flaky, terminated can happen before exited
       if (!GithubUtils.isCI()) {
-        client.exited()
-        client.terminated()
+        client.exited(timeout = 4.seconds)
+        client.terminated(timeout = 4.seconds)
       }
     }
 


### PR DESCRIPTION
Fix #628 

Remove `-indent` and `-rewrite` options when evaluating expression