### PR TITLE
Automatically close debug server after terminated event

### DIFF
--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/DebugConfig.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/DebugConfig.scala
@@ -14,7 +14,6 @@ object StepFiltersConfig {
 
 final case class DebugConfig(
     gracePeriod: Duration,
-    autoCloseSession: Boolean,
     testMode: Boolean,
     evaluationMode: DebugConfig.EvaluationMode,
     stepFilters: StepFiltersConfig
@@ -23,7 +22,6 @@ final case class DebugConfig(
 object DebugConfig {
   def default: DebugConfig = DebugConfig(
     5.seconds,
-    autoCloseSession = true,
     testMode = false,
     evaluationMode = DebugConfig.MixedEvaluation,
     stepFilters = StepFiltersConfig.default

--- a/modules/sbt-plugin/src/main/scala/ch/epfl/scala/debugadapter/sbtplugin/DebugAdapterPlugin.scala
+++ b/modules/sbt-plugin/src/main/scala/ch/epfl/scala/debugadapter/sbtplugin/DebugAdapterPlugin.scala
@@ -478,7 +478,7 @@ object DebugAdapterPlugin extends sbt.AutoPlugin {
         debugServers.get(target).foreach(_.close())
         val server = DebugServer(debuggee, resolver, new LoggerAdapter(logger), address, config)
         debugServers.update(target, server)
-        Await.result(server.start(), Duration.Inf)
+        Await.result(server.run(), Duration.Inf)
       } catch {
         case NonFatal(cause) =>
           logger.error("Failed to start server")

--- a/modules/tests/src/test/scala/ch/epfl/scala/debugadapter/DebugServerTests.scala
+++ b/modules/tests/src/test/scala/ch/epfl/scala/debugadapter/DebugServerTests.scala
@@ -287,7 +287,7 @@ class DebugServerTests extends DebugTestSuite {
 
   test("should accept a second connection when the session disconnects with restart = true") {
     val debuggee = new MockDebuggee()
-    val handler = startDebugServer(debuggee, gracePeriod = Duration.Zero)
+    val handler = runDebugServer(debuggee, gracePeriod = Duration.Zero)
     val client1 = TestingDebugClient.connect(handler.uri)
 
     try {
@@ -305,7 +305,7 @@ class DebugServerTests extends DebugTestSuite {
 
   test("should not accept a second connection when the session disconnects with restart = false") {
     val debuggee = new MockDebuggee()
-    val handler = startDebugServer(debuggee, gracePeriod = Duration.Zero)
+    val handler = runDebugServer(debuggee, gracePeriod = Duration.Zero)
     val client1 = TestingDebugClient.connect(handler.uri)
 
     try {


### PR DESCRIPTION
This should solve a memory leak in the debugger.