### PR TITLE
Improved Performance of loadClassesByScalaName

### DIFF
--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/SourceLookUpProvider.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/SourceLookUpProvider.scala
@@ -97,11 +97,14 @@ private[debugadapter] final class SourceLookUpProvider(
   }
 
   private def loadClassesByScalaName: Map[String, Seq[String]] =
-    classPathEntries.map(_.classesByScalaName).foldLeft(Map.empty[String, Seq[String]]) { (x, y) =>
-      (x.keys ++ y.keys).map { k =>
-        k -> (x.getOrElse(k, Seq.empty) ++ y.getOrElse(k, Seq.empty))
-      }.toMap
+    //Note: This can be a hotspot as there can be a LOT of classes. Keep perf in mind when refactoring
+    classPathEntries.map(_.classesByScalaName).foldLeft(Map.empty[String, Seq[String]]){ (accum, currMap) =>
+      currMap.foldLeft(accum){ (accumInner, kv) =>{
+        val (k,v) = kv
+        accumInner.updated(k, accumInner.getOrElse(k, Seq.empty) ++v)
+      }
     }
+  }
 }
 
 private[debugadapter] object SourceLookUpProvider {

--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/SourceLookUpProvider.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/SourceLookUpProvider.scala
@@ -97,14 +97,15 @@ private[debugadapter] final class SourceLookUpProvider(
   }
 
   private def loadClassesByScalaName: Map[String, Seq[String]] =
-    //Note: This can be a hotspot as there can be a LOT of classes. Keep perf in mind when refactoring
-    classPathEntries.map(_.classesByScalaName).foldLeft(Map.empty[String, Seq[String]]){ (accum, currMap) =>
-      currMap.foldLeft(accum){ (accumInner, kv) =>{
-        val (k,v) = kv
-        accumInner.updated(k, accumInner.getOrElse(k, Seq.empty) ++v)
+    // Note: This can be a hotspot as there can be a LOT of classes. Keep perf in mind when refactoring
+    classPathEntries.map(_.classesByScalaName).foldLeft(Map.empty[String, Seq[String]]) { (accum, currMap) =>
+      currMap.foldLeft(accum) { (accumInner, kv) =>
+        {
+          val (k, v) = kv
+          accumInner.updated(k, accumInner.getOrElse(k, Seq.empty) ++ v)
+        }
       }
     }
-  }
 }
 
 private[debugadapter] object SourceLookUpProvider {


### PR DESCRIPTION
Refactored SourceLookUpProvider.loadClassesByScalaName() to be more efficient. 

The issue presented itself in 4.0.0 (related to the HotCodeReplace feature). The debug loading times became really slow.

On my large project, the loading went from 75s back to a normal 12s. (12s is about what I saw in v3.1.6).  

This should resolve https://github.com/scalameta/metals/issues/6544