### PR TITLE
Reverse entries in `SourceLookUpProvider`

### DIFF
--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/SourceLookUpProvider.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/SourceLookUpProvider.scala
@@ -123,6 +123,7 @@ private[debugadapter] object SourceLookUpProvider {
     val allLookUps = parallelEntries
       .map(entry => ClassEntryLookUp(entry, entry.sourceEntries.flatMap(sourceLookUps.apply), logger))
       .seq
+      .reverse
     val sourceUriToClassPathEntry = allLookUps
       .flatMap(lookup => lookup.sources.map(uri => (uri, lookup)))
       .toMap


### PR DESCRIPTION
If 2 entries contain the same class name, the first class should shadow the second class, because that the one loaded by the JDK `ClassLoader`.

Conicidentally that should fix https://github.com/scalameta/metals/issues/5807.