### PR TITLE
improvement: Add location to failure to help mark it in VS Code

### DIFF
--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/Debuggee.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/Debuggee.scala
@@ -1,8 +1,10 @@
 package ch.epfl.scala.debugadapter
 
-import java.nio.file.Path
-import java.io.File
+import ch.epfl.scala.debugadapter.internal.SourceLookUpProvider
+
 import java.io.Closeable
+import java.io.File
+import java.nio.file.Path
 
 trait Debuggee {
   def name: String
@@ -19,4 +21,10 @@ trait Debuggee {
   def classPath: Seq[Path] = classPathEntries.map(_.absolutePath)
   def classEntries: Seq[ClassEntry] = classPathEntries ++ javaRuntime
   def classPathString: String = classPath.mkString(File.pathSeparator)
+
+  @volatile private[debugadapter] var sourceLookUpProvider: Option[SourceLookUpProvider] = None
+
+  private[debugadapter] def setSourceLookUpProvider(provider: SourceLookUpProvider): Unit = {
+    sourceLookUpProvider = Some(provider)
+  }
 }

--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/ClassEntryLookUp.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/ClassEntryLookUp.scala
@@ -37,6 +37,7 @@ private class ClassEntryLookUp(
     sourceUriToSourceFile: Map[SourceFileKey, SourceFile],
     sourceUriToClassFiles: Map[SourceFileKey, Seq[ClassFile]],
     classNameToSourceFile: Map[String, SourceFile],
+    sourceNameToSourceFile: Map[String, Seq[SourceFile]],
     missingSourceFileClassFiles: Seq[ClassFile],
     val orphanClassFiles: Seq[ClassFile],
     logger: Logger
@@ -48,6 +49,10 @@ private class ClassEntryLookUp(
     classNameToSourceFile.keys ++
       orphanClassFiles.map(_.fullyQualifiedName) ++
       missingSourceFileClassFiles.map(_.fullyQualifiedName)
+  }
+
+  def uriFromFilename(filename: String): Option[URI] = {
+    sourceNameToSourceFile.get(filename).flatMap(_.headOption).map(_.uri)
   }
 
   def classesByScalaName: Map[String, Iterable[String]] =
@@ -257,6 +262,7 @@ private object ClassEntryLookUp {
       sourceUriToSourceFile,
       sourceUriToClassFiles.toMap,
       classNameToSourceFile.toMap,
+      sourceNameToSourceFile,
       missingSourceFileClassFiles.toSeq,
       orphanClassFiles.toSeq,
       logger

--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/DebugSession.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/DebugSession.scala
@@ -22,6 +22,7 @@ import scala.concurrent.Promise
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
+import com.microsoft.java.debug.core.adapter.ISourceLookUpProvider
 
 /**
  * This debug adapter maintains the lifecycle of the debuggee in separation from JDI.
@@ -152,6 +153,10 @@ private[debugadapter] final class DebugSession private (
         val debugConfig =
           if (launchArgs.scalaStepFilters == null) config else config.copy(stepFilters = launchArgs.scalaStepFilters)
         context.configure(tools, debugConfig)
+        context.getProvider(classOf[ISourceLookUpProvider]) match {
+          case provider: SourceLookUpProvider =>
+            debuggee.setSourceLookUpProvider(provider)
+        }
         // launch request is implemented by spinning up a JVM
         // and sending an attach request to the java DapServer
         launchedRequests.add(requestId)

--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/SourceLookUpProvider.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/SourceLookUpProvider.scala
@@ -21,6 +21,12 @@ private[debugadapter] final class SourceLookUpProvider(
     getSourceFileByClassname(fqcn).map(_.toString).orNull
   }
 
+  def getSourceFileURI(fileName: String): Option[URI] = {
+    classPathEntries.iterator.map(_.uriFromFilename(fileName)).collectFirst { case Some(value) =>
+      value
+    }
+  }
+
   override def getSourceContents(uri: String): String = {
     val sourceUri = URI.create(uri)
     sourceUriToClassPathEntry

--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/testing/TestSuiteSummary.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/testing/TestSuiteSummary.scala
@@ -36,14 +36,20 @@ object SingleTestResult {
     def apply(testName: String): Skipped = new Skipped("skipped", testName)
   }
 
+  final class Location(
+      val file: String,
+      val line: Int
+  )
+
   final class Failed private (
       val kind: String,
       val testName: String,
       val duration: Long,
-      val error: String
+      val error: String,
+      val location: Option[Location]
   ) extends SingleTestSummary
   object Failed {
-    def apply(testName: String, duration: Long, error: String): Failed =
-      new Failed("failed", testName, duration, error)
+    def apply(testName: String, duration: Long, error: String, location: Option[Location] = None): Failed =
+      new Failed("failed", testName, duration, error, location)
   }
 }

--- a/modules/sbt-plugin/src/main/scala/ch/epfl/scala/debugadapter/sbtplugin/DebugAdapterPlugin.scala
+++ b/modules/sbt-plugin/src/main/scala/ch/epfl/scala/debugadapter/sbtplugin/DebugAdapterPlugin.scala
@@ -472,8 +472,8 @@ object DebugAdapterPlugin extends sbt.AutoPlugin {
     val address = new DebugServer.Address()
     jobService.runInBackground(scope, state) { (logger, _) =>
       try {
-        val debuggee = debuggeeF(logger)
         val resolver = resolverF(logger)
+        val debuggee = debuggeeF(logger)
         // if there is a server for this target then close it
         debugServers.get(target).foreach(_.close())
         val server = DebugServer(debuggee, resolver, new LoggerAdapter(logger), address, config)

--- a/modules/sbt-plugin/src/main/scala/ch/epfl/scala/debugadapter/sbtplugin/internal/SbtDebuggee.scala
+++ b/modules/sbt-plugin/src/main/scala/ch/epfl/scala/debugadapter/sbtplugin/internal/SbtDebuggee.scala
@@ -68,7 +68,7 @@ private[debugadapter] final class TestSuitesDebuggee(
     s"${getClass.getSimpleName}(${target.uri}, [${tests.mkString(", ")}])"
 
   override def run(listener: DebuggeeListener): CancelableFuture[Unit] = {
-    val eventHandler = new SbtTestSuiteEventHandler(listener)
+    val eventHandler = new SbtTestSuiteEventHandler(listener, () => sourceLookUpProvider)
 
     @annotation.tailrec
     def receiveLogs(is: ObjectInputStream, os: ObjectOutputStream): Unit = {

--- a/modules/sbt-plugin/src/main/scala/ch/epfl/scala/debugadapter/sbtplugin/internal/SbtTestSuiteEventHandler.scala
+++ b/modules/sbt-plugin/src/main/scala/ch/epfl/scala/debugadapter/sbtplugin/internal/SbtTestSuiteEventHandler.scala
@@ -3,12 +3,14 @@ package ch.epfl.scala.debugadapter.sbtplugin.internal
 import ch.epfl.scala.debugadapter.DebuggeeListener
 import ch.epfl.scala.debugadapter.testing.TestSuiteEventHandler
 import ch.epfl.scala.debugadapter.testing.TestSuiteEvent
+import ch.epfl.scala.debugadapter.internal.SourceLookUpProvider
 
 /**
  * Extracts information about tests execution and send it to the DebuggeeListener.
  * Then DebugeeListener forwards it to the DAP client.
  */
-class SbtTestSuiteEventHandler(listener: DebuggeeListener) extends TestSuiteEventHandler {
+class SbtTestSuiteEventHandler(listener: DebuggeeListener, sourceLookUpProvider: () => Option[SourceLookUpProvider])
+    extends TestSuiteEventHandler {
 
   def handle(event: TestSuiteEvent): Unit =
     event match {
@@ -16,7 +18,7 @@ class SbtTestSuiteEventHandler(listener: DebuggeeListener) extends TestSuiteEven
       case TestSuiteEvent.Warn(s) => listener.out(s)
       case TestSuiteEvent.Error(s) => listener.err(s)
       case results: TestSuiteEvent.Results =>
-        val testResults = TestSuiteEventHandler.summarizeResults(results)
+        val testResults = TestSuiteEventHandler.summarizeResults(results, sourceLookUpProvider())
         listener.testResult(testResults)
       case _ => ()
     }


### PR DESCRIPTION
I did a similar thing in https://github.com/scalameta/metals-vscode/pull/1571 but I wonder if it would safer here.

@adpi2 any idea if we can get a full path easily instead of just the name? Otherwise, it seems the regex is an ok solution.