### PR TITLE
Improve perf of Scala2Decoder

### DIFF
--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/ClassEntryLookUp.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/ClassEntryLookUp.scala
@@ -42,6 +42,7 @@ private class ClassEntryLookUp(
     logger: Logger
 ) {
   private val sourceLineCache = mutable.Map.empty[SourceLine, Seq[ClassFile]]
+  private val scalaSigCache = mutable.Map.empty[String, Option[ScalaSig]]
 
   def sources: Iterable[SanitizedUri] = sourceUriToSourceFile.keys
   def fullyQualifiedNames: Iterable[String] = {
@@ -145,7 +146,7 @@ private class ClassEntryLookUp(
       else scalaSigs.headOption
     }
 
-    fromClass.orElse(fromSource)
+    scalaSigCache.getOrElseUpdate(fqcn, fromClass.orElse(fromSource))
   }
 }
 

--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/SourceLookUpProvider.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/SourceLookUpProvider.scala
@@ -9,11 +9,11 @@ import scala.collection.parallel.immutable.ParVector
 
 private[debugadapter] final class SourceLookUpProvider(
     private[internal] var classPathEntries: Seq[ClassEntryLookUp],
-    private var sourceUriToClassPathEntry: Map[SourceFileKey, ClassEntryLookUp],
+    private var sourceUriToClassPathEntry: Map[SanitizedUri, ClassEntryLookUp],
     private var fqcnToClassPathEntry: Map[String, ClassEntryLookUp],
     logger: Logger
 ) extends ISourceLookUpProvider {
-  var classesByScalaNameMap: Map[String, Seq[String]] = loadClassesByScalaName
+  private var classesByScalaNameMap: Map[String, Seq[String]] = loadClassesByScalaName
 
   override def supportsRealtimeBreakpointVerification(): Boolean = true
 
@@ -24,7 +24,7 @@ private[debugadapter] final class SourceLookUpProvider(
   override def getSourceContents(uri: String): String = {
     val sourceUri = URI.create(uri)
     sourceUriToClassPathEntry
-      .get(SourceFileKey(sourceUri))
+      .get(SanitizedUri(sourceUri))
       .flatMap(_.getSourceContent(sourceUri))
       .orNull
   }
@@ -41,7 +41,7 @@ private[debugadapter] final class SourceLookUpProvider(
         val resolvedName = uri.getSchemeSpecificPart
         lines.map(_ => resolvedName)
       case _ =>
-        val key = SourceFileKey(uri);
+        val key = SanitizedUri(uri);
         sourceUriToClassPathEntry.get(key) match {
           case None => lines.map(_ => null)
           case Some(entry) =>

--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/JdiClassLoader.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/evaluator/JdiClassLoader.scala
@@ -90,7 +90,6 @@ private[internal] class JdiClassLoader(
         case c: CharValue => Safe(value)
         case _ => mirrorOf(value.value.toString)
       }
-      _ = getClass
       (className, sig) = value.value match {
         case _: BooleanValue => ("java.lang.Boolean", "(Ljava/lang/String;)Ljava/lang/Boolean;")
         case _: ByteValue => ("java.lang.Byte", "(Ljava/lang/String;)Ljava/lang/Byte;")

--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/stacktrace/JdiExtensions.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/stacktrace/JdiExtensions.scala
@@ -43,8 +43,8 @@ object JdiExtensions {
       method.name.contains("$lzyINIT") || method.name.contains("$lzycompute")
 
     def isLazyGetter: Boolean =
-      method.argumentTypes.asScala.toSeq match {
-        case Seq(argType) => lazyTypes.contains(argType.name)
+      method.argumentTypeNames.asScala.toSeq match {
+        case Seq(argTypeName) => lazyTypes.contains(argTypeName)
         case _ => false
       }
 

--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/stacktrace/JdiExtensions.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/stacktrace/JdiExtensions.scala
@@ -31,7 +31,7 @@ object JdiExtensions {
       method.name == "<clinit>"
 
     def isAnonFunction: Boolean =
-      method.name.matches(".+\\$anonfun\\$\\d+")
+      method.name.matches(".+\\$anonfun(\\$.+)?\\$\\d+")
 
     def isLiftedMethod: Boolean =
       method.name.matches(".+\\$\\d+")

--- a/modules/tests/src/test/scala/ch/epfl/scala/debugadapter/internal/ClassEntryLookUpSpec.scala
+++ b/modules/tests/src/test/scala/ch/epfl/scala/debugadapter/internal/ClassEntryLookUpSpec.scala
@@ -23,7 +23,7 @@ class ClassEntryLookUpSpec extends FunSuite {
       "example.Main$Hello$InnerHello$1"
 
     val className =
-      lookUp.getFullyQualifiedClassName(SourceFileKey(expectedSourceFile), 14)
+      lookUp.getFullyQualifiedClassName(SanitizedUri(expectedSourceFile), 14)
     assert(className.contains(expectedClassName))
 
     val sourceFile = lookUp.getSourceFileURI(expectedClassName)
@@ -42,7 +42,7 @@ class ClassEntryLookUpSpec extends FunSuite {
     val expectedClassName = "cats.instances.ListInstances$$anon$1"
 
     val className =
-      lookUp.getFullyQualifiedClassName(SourceFileKey(expectedSourceFile), 28)
+      lookUp.getFullyQualifiedClassName(SanitizedUri(expectedSourceFile), 28)
     assert(className.contains(expectedClassName))
 
     val sourceFile = lookUp.getSourceFileURI(expectedClassName)
@@ -99,8 +99,8 @@ class ClassEntryLookUpSpec extends FunSuite {
     assert(sourceFile.contains("scala-debug-adapter"))
 
     val moddedSourceFile = sourceFile.replace("scala-debug-adapter", "SCALA-deBug-Adapter")
-    val sourceFileKey = SourceFileKey(toUri(moddedSourceFile))
-    val className = lookUp.getFullyQualifiedClassName(sourceFileKey, 14)
+    val sourceUri = SanitizedUri(toUri(moddedSourceFile))
+    val className = lookUp.getFullyQualifiedClassName(sourceUri, 14)
 
     val expectedClassName = if (isFilesystemCaseInsensitive) Some("example.Main$Hello$InnerHello$1") else None
     assertEquals(className, expectedClassName)
@@ -116,11 +116,11 @@ class ClassEntryLookUpSpec extends FunSuite {
     val moddedSourceJar = sourceJar.replace("cats-core", "Cats-CoRe")
     val moddedsourceFile = URI.create(s"jar:${toUri(moddedSourceJar)}!/cats/instances/list.scala")
     val expectedClassName = if (isFilesystemCaseInsensitive) Some("cats.instances.ListInstances$$anon$1") else None
-    val obtainedClassName = lookUp.getFullyQualifiedClassName(SourceFileKey(moddedsourceFile), 28)
+    val obtainedClassName = lookUp.getFullyQualifiedClassName(SanitizedUri(moddedsourceFile), 28)
     assertEquals(obtainedClassName, expectedClassName)
 
     val invalidSourceFile = URI.create(s"jar:file:${toUri(sourceJar)}!/caTs/Instances/list.scala")
-    val notFound = lookUp.getFullyQualifiedClassName(SourceFileKey(invalidSourceFile), 28)
+    val notFound = lookUp.getFullyQualifiedClassName(SanitizedUri(invalidSourceFile), 28)
     assert(notFound.isEmpty)
   }
 

--- a/modules/tests/src/test/scala/ch/epfl/scala/debugadapter/internal/MetalsClassBreakpointSuite.scala
+++ b/modules/tests/src/test/scala/ch/epfl/scala/debugadapter/internal/MetalsClassBreakpointSuite.scala
@@ -171,8 +171,8 @@ class MetalsClassBreakpointSuite extends FunSuite {
     val lineNumber = original.linesIterator.toSeq.indexWhere(_.contains(">>")) + 1
     val debuggee = TestingDebuggee.mainClass(source, "Main", scalaVersion)
     val lookUp = ClassEntryLookUp(debuggee.mainModule, NoopLogger)
-    val sourceFileKey = SourceFileKey(debuggee.sourceFiles.head.toUri)
-    val className = lookUp.getFullyQualifiedClassName(sourceFileKey, lineNumber)
+    val sourceUri = SanitizedUri(debuggee.sourceFiles.head.toUri)
+    val className = lookUp.getFullyQualifiedClassName(sourceUri, lineNumber)
     assert(className.contains(expectedClassName))
   }
 }


### PR DESCRIPTION
Try fix #780 

- Replace `argumentTypes` by `argumentTypeNames`
- Fix `isAnonFunction` matcher on Scala 2
- Cache scala sigs in `ClassEntryLookUp`