### PR TITLE
fix(DebugAdaptorPlugin): parsing envVars with edge cases

### DIFF
--- a/modules/sbt-plugin/src/main/scala/ch/epfl/scala/debugadapter/sbtplugin/DebugAdapterPlugin.scala
+++ b/modules/sbt-plugin/src/main/scala/ch/epfl/scala/debugadapter/sbtplugin/DebugAdapterPlugin.scala
@@ -423,7 +423,7 @@ object DebugAdapterPlugin extends sbt.AutoPlugin {
 
     val additionalEnv = environmentVariables
       .foldLeft(Map.empty[String, String]) { case (env, line) =>
-        line.split('=', 2) match {
+        line.split("=", 2) match {
           case Array(key, value) => env + (key -> value)
           case _ => env
         }

--- a/modules/sbt-plugin/src/main/scala/ch/epfl/scala/debugadapter/sbtplugin/DebugAdapterPlugin.scala
+++ b/modules/sbt-plugin/src/main/scala/ch/epfl/scala/debugadapter/sbtplugin/DebugAdapterPlugin.scala
@@ -423,7 +423,7 @@ object DebugAdapterPlugin extends sbt.AutoPlugin {
 
     val additionalEnv = environmentVariables
       .foldLeft(Map.empty[String, String]) { case (env, line) =>
-        line.split('=') match {
+        line.split('=', 2) match {
           case Array(key, value) => env + (key -> value)
           case _ => env
         }


### PR DESCRIPTION
Currently we're observing an envvar parse bug in metals + sbt bsp mode:

- an envvar whose value includes `=` is stripped of them
  - e.g., "ENV=ZGlkIHlvdSB0cnkgZGVjb2RpbmcgdGhpcz8=" loses `=` at the end
- an envvar whose value is empty is omitted.
  - e.g., "ENV=" are not injected into the debuggee.

This PR tries to fix these issue.

Example:

![image](https://github.com/user-attachments/assets/888ac968-2abe-4af0-adb3-a25d4eaaa6f4)
