### PR TITLE
Add multi-output module support

### DIFF
--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/ClassPathEntry.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/ClassPathEntry.scala
@@ -2,6 +2,7 @@ package ch.epfl.scala.debugadapter
 
 import java.nio.file.Path
 import java.net.URL
+import scala.util.Try
 
 sealed trait ClassPathEntry extends ClassEntry {
   def absolutePath: Path
@@ -27,13 +28,45 @@ sealed trait ManagedEntry extends ClassPathEntry {
   def isJava: Boolean = scalaVersion.isEmpty
 }
 
+sealed trait ModuleEntry extends ManagedEntry {
+  def scalacOptions: Seq[String]
+}
+
 final case class Module(
     name: String,
     scalaVersion: Option[ScalaVersion],
     scalacOptions: Seq[String],
     absolutePath: Path,
     sourceEntries: Seq[SourceEntry]
-) extends ManagedEntry
+) extends ModuleEntry
+
+final case class MultiOutputModule(
+    name: String,
+    scalaVersion: Option[ScalaVersion],
+    scalacOptions: Seq[String],
+    absolutePath: Path,
+    classPath: Seq[Path],
+    sourceEntries: Seq[SourceEntry]
+) extends ModuleEntry {
+  def fullClassPath: Seq[Path] = (absolutePath +: classPath).distinct
+
+  override def classSystems: Seq[ClassSystem] =
+    fullClassPath.map(classSystem)
+
+  private def classSystem(path: Path): ClassSystem =
+    if (path.toString.endsWith(".jar")) ClassJar(path)
+    else ClassDirectory(path)
+
+  override def readBytes(classFile: String): Array[Byte] = {
+    val attempts =
+      classSystems.map(classSystem => Try(classSystem.readBytes(classFile)))
+    attempts
+      .collectFirst { case scala.util.Success(bytes) => bytes }
+      .getOrElse {
+        attempts.last.get
+      }
+  }
+}
 
 final case class Library(artifactId: String, version: String, absolutePath: Path, sourceEntries: Seq[SourceEntry])
     extends ManagedEntry {

--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/Debuggee.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/Debuggee.scala
@@ -14,9 +14,13 @@ trait Debuggee {
   def javaRuntime: Option[JavaRuntime]
   def observeClassUpdates(onClassUpdate: Seq[String] => Unit): Closeable
 
-  def managedEntries: Seq[ManagedEntry] = modules ++ libraries
+  def moduleEntries: Seq[ModuleEntry] = modules
+  def managedEntries: Seq[ManagedEntry] = moduleEntries ++ libraries
   def classPathEntries: Seq[ClassPathEntry] = managedEntries ++ unmanagedEntries
-  def classPath: Seq[Path] = classPathEntries.map(_.absolutePath)
+  def classPath: Seq[Path] = classPathEntries.flatMap {
+    case module: MultiOutputModule => module.fullClassPath
+    case entry => Seq(entry.absolutePath)
+  }
   def classEntries: Seq[ClassEntry] = classPathEntries ++ javaRuntime
   def classPathString: String = classPath.mkString(File.pathSeparator)
 }

--- a/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/DebugTools.scala
+++ b/modules/core/src/main/scala/ch/epfl/scala/debugadapter/internal/DebugTools.scala
@@ -134,7 +134,7 @@ object DebugTools {
     def loadExpressionCompiler(entry: ManagedEntry): Option[(ClassEntry, ExpressionCompiler)] = {
       val optionsToAdd = if (entry.isScala2) defaultScala2Options else Seq.empty
       val scalacOptions = entry match {
-        case module: Module => prepareOptions(module.scalacOptions, optionsToAdd)
+        case module: ModuleEntry => prepareOptions(module.scalacOptions, optionsToAdd)
         case lib: Library => optionsToAdd
       }
       for {

--- a/modules/tests/src/test/scala/ch/epfl/scala/debugadapter/internal/ClassEntryLookUpSpec.scala
+++ b/modules/tests/src/test/scala/ch/epfl/scala/debugadapter/internal/ClassEntryLookUpSpec.scala
@@ -2,6 +2,7 @@ package ch.epfl.scala.debugadapter.internal
 
 import ch.epfl.scala.debugadapter.testfmk.TestingResolver
 import ch.epfl.scala.debugadapter.testfmk.TestingDebuggee
+import ch.epfl.scala.debugadapter.MultiOutputModule
 import ch.epfl.scala.debugadapter.ScalaVersion
 import ch.epfl.scala.debugadapter.SourceJar
 
@@ -10,6 +11,7 @@ import ch.epfl.scala.debugadapter.testfmk.NoopLogger
 import munit.FunSuite
 import scala.util.Properties
 import java.nio.file.Paths
+import java.nio.file.Files
 
 class ClassEntryLookUpSpec extends FunSuite {
   val isFilesystemCaseInsensitive = Properties.isWin || Properties.isMac
@@ -28,6 +30,29 @@ class ClassEntryLookUpSpec extends FunSuite {
 
     val sourceFile = lookUp.getSourceFileURI(expectedClassName)
     assert(sourceFile.contains(expectedSourceFile))
+  }
+
+  test("additional-module-class-path") {
+    val debuggee = TestingDebuggee.scalaBreakpointTest(ScalaVersion.`2.12`)
+    val emptyClassDirectory = Files.createTempDirectory("empty-classes")
+    val module = MultiOutputModule(
+      name = debuggee.mainModule.name,
+      scalaVersion = debuggee.mainModule.scalaVersion,
+      scalacOptions = debuggee.mainModule.scalacOptions,
+      absolutePath = emptyClassDirectory,
+      classPath = Seq(emptyClassDirectory, debuggee.mainModule.absolutePath),
+      sourceEntries = debuggee.mainModule.sourceEntries
+    )
+    val lookUp = ClassEntryLookUp(module, NoopLogger)
+
+    val expectedSourceFile = debuggee.sourceFiles.head.toUri
+    val expectedClassName =
+      "example.Main$Hello$InnerHello$1"
+
+    val className =
+      lookUp.getFullyQualifiedClassName(SanitizedUri(expectedSourceFile), 14)
+    assert(className.contains(expectedClassName))
+    assert(module.classPath.contains(debuggee.mainModule.absolutePath))
   }
 
   test("should map source files to class names and backward, in dependency jars") {


### PR DESCRIPTION
Introduce `MultiOutputModule` so clients can associate a single module with multiple class output paths.