### PR TITLE
Release using Java 17

### DIFF
--- a/.github/workflows/release-full.yml
+++ b/.github/workflows/release-full.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: coursier/setup-action@v3.0.0
         with:
           apps: sbt
-          jvm: 'adopt:1.8.0-292'
+          jvm: 'adoptium:1.17.0.7'
       - run: sbt ci-release
         env:
           JAVA_DEBUG_VERSION: ${{ inputs.java-debug-version }}

--- a/build.sbt
+++ b/build.sbt
@@ -290,7 +290,7 @@ lazy val testOptionsSettings = Def.settings(
 
 lazy val scalacOptionsSettings = Def.settings(
   scalacOptions ++= onScalaVersion(
-    scala212 = Seq("-Xsource:3", "-Ywarn-unused-import", "-deprecation"),
+    scala212 = Seq("-Xsource:3", "-Ywarn-unused-import", "-deprecation", "-release:8"),
     scala213 = Seq("-Xsource:3", "-Wunused:imports", "-deprecation"),
     scala3 = Seq("-deprecation")
   ).value

--- a/build.sbt
+++ b/build.sbt
@@ -290,7 +290,7 @@ lazy val testOptionsSettings = Def.settings(
 
 lazy val scalacOptionsSettings = Def.settings(
   scalacOptions ++= onScalaVersion(
-    scala212 = Seq("-Xsource:3", "-Ywarn-unused-import", "-deprecation", "-release:8"),
+    scala212 = Seq("-Xsource:3", "-Ywarn-unused-import", "-deprecation", "-release", "8"),
     scala213 = Seq("-Xsource:3", "-Wunused:imports", "-deprecation"),
     scala3 = Seq("-deprecation")
   ).value


### PR DESCRIPTION
To publish the sbt 2.x plugin, a JVM 17+ is required in the release workflow. This bumps the JVM as needed and adds the release:8 flag on Scala 2.12 so that the bytecode is guaranteed to run on old JVMs.

Not fully tested as I can't run the release from local. Changes inspired by https://github.com/sbt/sbt-license-report/pull/226/changes solving a similar problem.

Closes #993.